### PR TITLE
docs: add instruction to pass in token for JWT auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ var client = new RealtimeClient(process.env.REALTIME_URL)
 client.connect()
 ```
 
+You can pass in your JWT If you have enabled JWT authorization in Supabase [Realtime](https://github.com/supabase/realtime) server.
+
+```js
+import { RealtimeClient } from '@supabase/realtime-js'
+
+var client = new RealtimeClient(process.env.REALTIME_URL, { params: { token: 'token123' }})
+client.connect()
+```
+
+See [Realtime: Channels Authorization](https://github.com/supabase/realtime#channels-authorization) for more information.
+
 **Socket Hooks**
 
 ```js


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

## What is the new behavior?

Add instruction to pass in token for when Realtime server is running in secure mode.

## Additional context

Related issue: https://github.com/supabase/realtime/issues/109
