### PR TITLE
Client functionality of bind all events

### DIFF
--- a/src/RealtimeSubscription.ts
+++ b/src/RealtimeSubscription.ts
@@ -180,7 +180,14 @@ export default class RealtimeSubscription {
     }
 
     this.bindings
-      .filter((bind) => bind.event === event)
+      .filter((bind) => {
+        // bind all realtime events
+        if (bind.event === '*') {
+          return event === payload.type
+        } else {
+          return bind.event === event
+        }
+      })
       .map((bind) => bind.callback(handledPayload, ref))
   }
 

--- a/test/channel_test.js
+++ b/test/channel_test.js
@@ -264,7 +264,7 @@ describe('joinPush', () => {
     })
 
     it("sends and empties channel's buffered pushEvents", () => {
-      const pushEvent = { send() {} }
+      const pushEvent = { send() { } }
       const spy = sinon.spy(pushEvent, 'send')
 
       channel.pushBuffer.push(pushEvent)
@@ -419,7 +419,7 @@ describe('joinPush', () => {
     })
 
     it("does not trigger channel's buffered pushEvents", () => {
-      const pushEvent = { send: () => {} }
+      const pushEvent = { send: () => { } }
       const spy = sinon.spy(pushEvent, 'send')
 
       channel.pushBuffer.push(pushEvent)
@@ -670,6 +670,21 @@ describe('on', () => {
     channel.trigger('event', {}, defaultRef)
 
     assert.ok(!ignoredSpy.called)
+  })
+
+  it('"*" bind all events', () => {
+    const spy = sinon.spy()
+
+    channel.trigger('INSERT', {}, defaultRef)
+    assert.ok(!spy.called)
+
+    channel.on('*', spy)
+    channel.trigger('*', { type: 'INSERT' }, defaultRef)
+    assert.ok(!spy.called)
+
+    channel.on('*', spy)
+    channel.trigger('INSERT', { type: 'INSERT' }, defaultRef)
+    assert.ok(spy.called)
   })
 })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

A proposal on reducing traffic twice by implementing the "bind all events" only on the client. No need more send events with "*", after that fix, you could remove `RealtimeWeb.Endpoint.broadcast_from!(self(), topic, "*", txn)` in the `RealtimeWeb.RealtimeChannel.handle_realtime_transaction`

## What is the current behavior?

In current behavior, the server always sends two messages, were different only in event name. On the client-side simple check matching by event name.

## What is the new behavior?

The new behavior can bind all events where the event name equals type in the payload.
Example of current event
```json
{
  "event": "INSERT",
  "payload": {
    "columns": [],
    "commit_timestamp": "2021-02-12T16:03:31Z",
    "record":{},
    "schema": "public",
    "table": "users",
    "type": "INSERT"
  },
  "ref": null,
  "topic": "realtime:*"
}
```

## Additional context

https://github.com/supabase/realtime/issues/119#issuecomment-777783037
