### PR TITLE
docs: update RealtimeClient param key from token to apikey

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can pass in your JWT If you have enabled JWT authorization in Supabase [Real
 ```js
 import { RealtimeClient } from '@supabase/realtime-js'
 
-var client = new RealtimeClient(process.env.REALTIME_URL, { params: { token: 'token123' }})
+var client = new RealtimeClient(process.env.REALTIME_URL, { params: { apikey: 'token123' }})
 client.connect()
 ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Specifies RealtimeClient param key is `token`

## What is the new behavior?

Specifies RealtimeClient param key is `apikey`

## Additional context

Related issue: [Phoenix tokens for channel auth #95
](https://github.com/supabase/realtime/issues/95)

Related comment: https://github.com/supabase/realtime/issues/95#issuecomment-777868713

**NOTE**:

Should be merged when [feat: change socket param from token to apikey #122](https://github.com/supabase/realtime/pull/122) has been merged to `master`.