### PR TITLE
fix: large influx of messages prevents heartbeat reply

### DIFF
--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -41,7 +41,7 @@ export default class RealtimeClient {
   transport: any = WebSocket
   heartbeatIntervalMs: number = 30000
   longpollerTimeout: number = 20000
-  heartbeatTimer: number | undefined = undefined
+  heartbeatTimer: ReturnType<typeof setInterval> | undefined = undefined
   pendingHeartbeatRef: string | null = null
   ref: number = 0
   reconnectTimer: Timer
@@ -324,7 +324,7 @@ export default class RealtimeClient {
   private _onConnClose(event: any) {
     this.log('transport', 'close', event)
     this._triggerChanError()
-    clearInterval(this.heartbeatTimer)
+    this.heartbeatTimer && clearInterval(this.heartbeatTimer)
     this.reconnectTimer.scheduleTimeout()
     this.stateChangeCallbacks.close.forEach((callback) => callback(event))
   }
@@ -360,9 +360,10 @@ export default class RealtimeClient {
 
   private _resetHeartbeat() {
     this.pendingHeartbeatRef = null
-    clearInterval(this.heartbeatTimer)
-    this.heartbeatTimer = <any>(
-      setInterval(() => this._sendHeartbeat(), this.heartbeatIntervalMs)
+    this.heartbeatTimer && clearInterval(this.heartbeatTimer)
+    this.heartbeatTimer = setInterval(
+      () => this._sendHeartbeat(),
+      this.heartbeatIntervalMs
     )
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Large influx of messages prevents heartbeat reply which forces client to re-connect. As a result, client stops receiving messages after re-connect.

Related issue: #77 

## What is the new behavior?

Client no longer re-connects when there is a large influx of messages. As a result, client receives all messages sent from server.

## Additional context

This solution was proposed by @abc3 on issue #77.

Although heartbeat can be reset whenever any message comes in, this limits the scope to only specific realtime db change messages where `event`(e.g. `"INSERT"`) aligns with the payload's `type` (e.g. `"INSERT"`). 