### PR TITLE
Add serializer to decode binary messages

### DIFF
--- a/src/lib/serializer.ts
+++ b/src/lib/serializer.ts
@@ -1,0 +1,49 @@
+// This file draws heavily from https://github.com/phoenixframework/phoenix/commit/cf098e9cf7a44ee6479d31d911a97d3c7430c6fe
+// License: https://github.com/phoenixframework/phoenix/blob/master/LICENSE.md
+
+export default class Serializer {
+  HEADER_LENGTH = 1
+
+  decode(rawPayload: ArrayBuffer | string, callback: Function) {
+    if (rawPayload.constructor === ArrayBuffer) {
+      return callback(this._binaryDecode(rawPayload))
+    }
+
+    if (typeof rawPayload === 'string') {
+      return callback(JSON.parse(rawPayload))
+    }
+
+    return callback({})
+  }
+
+  private _binaryDecode(buffer: ArrayBuffer) {
+    const view = new DataView(buffer)
+    const decoder = new TextDecoder()
+
+    return this._decodeBroadcast(buffer, view, decoder)
+  }
+
+  private _decodeBroadcast(
+    buffer: ArrayBuffer,
+    view: DataView,
+    decoder: TextDecoder
+  ): {
+    ref: null
+    topic: string
+    event: string
+    payload: object
+  } {
+    const topicSize = view.getUint8(1)
+    const eventSize = view.getUint8(2)
+    let offset = this.HEADER_LENGTH + 2
+    const topic = decoder.decode(buffer.slice(offset, offset + topicSize))
+    offset = offset + topicSize
+    const event = decoder.decode(buffer.slice(offset, offset + eventSize))
+    offset = offset + eventSize
+    const data = JSON.parse(
+      decoder.decode(buffer.slice(offset, buffer.byteLength))
+    )
+
+    return { ref: null, topic: topic, event: event, payload: data }
+  }
+}

--- a/test/socket_test.js
+++ b/test/socket_test.js
@@ -729,6 +729,24 @@ describe('custom encoder and decoder', () => {
     })
   })
 
+  it('decodes ArrayBuffer by default', () => {
+    socket = new RealtimeClient('wss://example.com/socket')
+    const buffer = new Uint8Array([2, 20, 6, 114, 101, 97, 108, 116, 105,
+      109, 101, 58, 112, 117, 98, 108, 105, 99, 58, 116, 101, 115, 116, 73,
+      78, 83, 69, 82, 84, 123, 34, 102, 111, 111, 34, 58, 34, 98, 97, 114, 34, 125]).buffer
+
+    socket.decode(buffer, decoded => {
+      assert.deepStrictEqual(
+        decoded, {
+          ref: null,
+          topic: "realtime:public:test",
+          event: "INSERT",
+          payload: { foo: 'bar' }
+        }
+      )
+    })
+  })
+
   it('allows custom decoding when using WebSocket transport', () => {
     let decoder = (payload, callback) => callback('decode works')
     socket = new RealtimeClient('wss://example.com/socket', {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Client can only decode json messages

## What is the new behavior?

Client can decode both json and binary messages

## Additional context

Related: https://github.com/supabase/realtime/pull/131