### PR TITLE
Making sure callback set on other events are not called for certain event

### DIFF
--- a/test/channel_test.js
+++ b/test/channel_test.js
@@ -666,6 +666,7 @@ describe('on', () => {
     assert.ok(!ignoredSpy.called)
 
     channel.on('event', spy)
+    channel.on('otherEvent', ignoredSpy)
 
     channel.trigger('event', {}, defaultRef)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix where the ignoredSpy was not being used.
This test checks if `ignoredSpy` had been called at the end, but since `ignoredSpy` has not been bound to any event subscription, it won't be called for any event triggers. Binding it to `otherEvent` will properly test this case. 

```javascript
  it('other event callbacks are ignored', () => {
    const spy = sinon.spy()
    const ignoredSpy = sinon.spy()

    channel.trigger('event', {}, defaultRef)

    assert.ok(!ignoredSpy.called)

    channel.on('event', spy)
    channel.on('otherEvent', ignoredSpy) // Newly Added line

    channel.trigger('event', {}, defaultRef)

    assert.ok(!ignoredSpy.called)
  })
```

I stumbled across this test code, and decided to open a PR, but apologies if I am missing some context and this code is working without the code that I added. 