### PR TITLE
Move @types/websocket from dependencies to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "@types/websocket": "^1.0.1",
         "websocket": "^1.0.34"
       },
       "devDependencies": {
         "@babel/runtime": "^7.9.2",
         "@supabase/doctest-js": "^0.1.0",
+        "@types/websocket": "^1.0.3",
         "babel-preset-env": "^1.7.0",
         "babel-register": "^6.26.0",
         "eslint": "^7.0.0",
@@ -1421,7 +1421,8 @@
     "node_modules/@types/node": {
       "version": "14.11.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
-      "integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw=="
+      "integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
+      "dev": true
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -1442,9 +1443,10 @@
       "dev": true
     },
     "node_modules/@types/websocket": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.1.tgz",
-      "integrity": "sha512-f5WLMpezwVxCLm1xQe/kdPpQIOmL0TXYx2O15VYfYzc7hTIdxiOoOvez+McSIw3b7z/1zGovew9YSL7+h4h7/Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.3.tgz",
+      "integrity": "sha512-ZdoTSwmDsKR7l1I8fpfQtmTI/hUwlOvE3q0iyJsp4tXU0MkdrYowimDzwxjhQvxU4qjhHLd3a6ig0OXRbLgIdw==",
+      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -12396,7 +12398,8 @@
     "@types/node": {
       "version": "14.11.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
-      "integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw=="
+      "integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
+      "dev": true
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -12417,9 +12420,10 @@
       "dev": true
     },
     "@types/websocket": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.1.tgz",
-      "integrity": "sha512-f5WLMpezwVxCLm1xQe/kdPpQIOmL0TXYx2O15VYfYzc7hTIdxiOoOvez+McSIw3b7z/1zGovew9YSL7+h4h7/Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.3.tgz",
+      "integrity": "sha512-ZdoTSwmDsKR7l1I8fpfQtmTI/hUwlOvE3q0iyJsp4tXU0MkdrYowimDzwxjhQvxU4qjhHLd3a6ig0OXRbLgIdw==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "docs:json": "typedoc --json docs/spec.json --mode modules --includeDeclarations --excludeExternals"
   },
   "dependencies": {
-    "@types/websocket": "^1.0.1",
     "websocket": "^1.0.34"
   },
   "devDependencies": {
     "@babel/runtime": "^7.9.2",
     "@supabase/doctest-js": "^0.1.0",
+    "@types/websocket": "^1.0.3",
     "babel-preset-env": "^1.7.0",
     "babel-register": "^6.26.0",
     "eslint": "^7.0.0",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Removes an unnecessary runtime dependency installation

## What is the current behavior?

Installing `@supabase/realtime-js` installs `@types/websocket` which has no runtime functionality.

## What is the new behavior?

Installing `@supabase/realtime-js` only installs `websocket` as a dependency.

## Additional context

Typically packages that are written in typescript only include type definitions as devDependencies.