### PR TITLE
Export type Options

### DIFF
--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -11,7 +11,7 @@ import RealtimeSubscription from './RealtimeSubscription'
 import { w3cwebsocket as WebSocket } from 'websocket'
 import Serializer from './lib/serializer'
 
-type Options = {
+export type Options = {
   transport?: WebSocket
   timeout?: number
   heartbeatIntervalMs?: number


### PR DESCRIPTION
This PR is in preparation for plumbing options through `SupabaseClient`. We need the options type exported to make TypeScript happy and not duplicate the type.