### PR TITLE
fix: type export issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,12 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@types/websocket": "^1.0.3",
         "websocket": "^1.0.34"
       },
       "devDependencies": {
         "@babel/runtime": "^7.9.2",
         "@supabase/doctest-js": "^0.1.0",
-        "@types/websocket": "^1.0.3",
         "babel-preset-env": "^1.7.0",
         "babel-register": "^6.26.0",
         "eslint": "^7.0.0",
@@ -1421,8 +1421,7 @@
     "node_modules/@types/node": {
       "version": "14.11.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
-      "integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
-      "dev": true
+      "integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -1446,7 +1445,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.3.tgz",
       "integrity": "sha512-ZdoTSwmDsKR7l1I8fpfQtmTI/hUwlOvE3q0iyJsp4tXU0MkdrYowimDzwxjhQvxU4qjhHLd3a6ig0OXRbLgIdw==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -2694,6 +2692,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.1.tgz",
       "integrity": "sha512-xowrxvpxojqkagPcWRQVXZl0YXhRhAtBEIq3VoER1NH5Mw1n1o0ojdspp+GS2J//2gCVyrzQDApQ4unGF+QOoA==",
+      "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "~3.7.0"
       }
@@ -10731,6 +10730,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.2.tgz",
       "integrity": "sha512-SwV++i2gTD5qh2XqaPzBnNX88N6HdyhQrNNRykvcS0QKvItV9u3vPEJr+X5Hhfb1JC0r0e1alL0iB09rY8+nmw==",
+      "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "~3.7.0"
       }
@@ -12398,8 +12398,7 @@
     "@types/node": {
       "version": "14.11.8",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.8.tgz",
-      "integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==",
-      "dev": true
+      "integrity": "sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -12423,7 +12422,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/websocket/-/websocket-1.0.3.tgz",
       "integrity": "sha512-ZdoTSwmDsKR7l1I8fpfQtmTI/hUwlOvE3q0iyJsp4tXU0MkdrYowimDzwxjhQvxU4qjhHLd3a6ig0OXRbLgIdw==",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "docs:json": "typedoc --json docs/spec.json --mode modules --includeDeclarations --excludeExternals"
   },
   "dependencies": {
+    "@types/websocket": "^1.0.3",
     "websocket": "^1.0.34"
   },
   "devDependencies": {
     "@babel/runtime": "^7.9.2",
     "@supabase/doctest-js": "^0.1.0",
-    "@types/websocket": "^1.0.3",
     "babel-preset-env": "^1.7.0",
     "babel-register": "^6.26.0",
     "eslint": "^7.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,12 @@
 import * as Transformers from './lib/transformers'
-import RealtimeClient from './RealtimeClient'
+import RealtimeClient, {
+  Options as RealtimeClientOptions,
+} from './RealtimeClient'
 import RealtimeSubscription from './RealtimeSubscription'
 
-export { RealtimeClient, RealtimeSubscription, Transformers }
+export {
+  RealtimeClient,
+  RealtimeClientOptions,
+  RealtimeSubscription,
+  Transformers,
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

[This PR](https://github.com/supabase/realtime-js/pull/95) didn't quite work right. Two issues: 

1. `@types/websocket` is an actual dependency but marked as devDep
2. It's easier on devs if we re-export from index.d.ts