### PR TITLE
Close open handles to allow testing without --exit flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build": "run-s clean format build:*",
     "build:main": "tsc -p tsconfig.json",
     "build:module": "tsc -p tsconfig.module.json",
-    "mocha": "node -r esm node_modules/.bin/mocha --exit ./test/**/*.js -r jsdom-global/register",
+    "mocha": "node -r esm node_modules/.bin/mocha ./test/**/*.js -r jsdom-global/register",
     "test": "run-s clean build mocha",
     "docs": "typedoc --mode file --target ES6 --theme minimal",
     "docs:json": "typedoc --json docs/spec.json --mode modules --includeDeclarations --excludeExternals"

--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -150,6 +150,9 @@ export default class RealtimeClient {
             this.conn.close()
           }
           this.conn = null
+          // remove open handles
+          this.heartbeatTimer && clearInterval(this.heartbeatTimer)
+          this.reconnectTimer.reset()
         }
         resolve({ error: null, data: true })
       } catch (error) {

--- a/src/RealtimeSubscription.ts
+++ b/src/RealtimeSubscription.ts
@@ -128,6 +128,9 @@ export default class RealtimeSubscription {
       this.socket.log('channel', `leave ${this.topic}`)
       this.trigger(CHANNEL_EVENTS.close, 'leave', this.joinRef())
     }
+    // Destroy joinPush to avoid connection timeouts during unscription phase
+    this.joinPush.destroy()
+
     let leavePush = new Push(this, CHANNEL_EVENTS.leave, {}, timeout)
     leavePush.receive('ok', () => onClose()).receive('timeout', () => onClose())
     leavePush.send()

--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -86,6 +86,11 @@ export default class Push {
     if (this.refEvent) this.channel.trigger(this.refEvent, { status, response })
   }
 
+  destroy() {
+    this._cancelRefEvent()
+    this._cancelTimeout()
+  }
+
   private _cancelRefEvent() {
     if (!this.refEvent) {
       return

--- a/test/channel_test.js
+++ b/test/channel_test.js
@@ -1,8 +1,5 @@
 import assert from 'assert'
-
-import jsdom from 'jsdom'
 import sinon from 'sinon'
-import { WebSocket, Server as WebSocketServer } from 'mock-socket'
 
 import { RealtimeSubscription, RealtimeClient } from '../dist/main'
 
@@ -13,7 +10,12 @@ const defaultTimeout = 10000
 
 describe('constructor', () => {
   beforeEach(() => {
-    socket = { timeout: 1234 }
+    socket = new RealtimeClient('/socket', { timeout: 1234 })
+  })
+
+  afterEach(async () => {
+    await socket.disconnect()
+    channel.unsubscribe()
   })
 
   it('sets defaults', () => {
@@ -45,6 +47,11 @@ describe('join', () => {
     socket = new RealtimeClient('wss://example.com/socket', { timeout: defaultTimeout })
 
     channel = socket.channel('topic', { one: 'two' })
+  })
+
+  afterEach(async () => {
+    await socket.disconnect()
+    channel.unsubscribe()
   })
 
   it('sets state to joining', () => {
@@ -171,8 +178,10 @@ describe('joinPush', () => {
     channel.subscribe()
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     clock.restore()
+    await socket.disconnect()
+    channel.unsubscribe()
   })
 
   describe("receives 'ok'", () => {
@@ -449,8 +458,10 @@ describe('onError', () => {
     channel.subscribe()
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     clock.restore()
+    await socket.disconnect()
+    channel.unsubscribe()
   })
 
   it("sets state to 'errored'", () => {
@@ -542,8 +553,10 @@ describe('onClose', () => {
     channel.subscribe()
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     clock.restore()
+    await socket.disconnect()
+    channel.unsubscribe()
   })
 
   it("sets state to 'closed'", () => {
@@ -594,6 +607,11 @@ describe('onMessage', () => {
     channel = socket.channel('topic', { one: 'two' })
   })
 
+  afterEach(async () => {
+    await socket.disconnect()
+    channel.unsubscribe()
+  })
+
   it('returns payload by default', () => {
     sinon.stub(socket, 'makeRef').callsFake(() => defaultRef)
     const payload = channel.onMessage('event', { one: 'two' }, defaultRef)
@@ -607,6 +625,11 @@ describe('canPush', () => {
     socket = new RealtimeClient('/socket')
 
     channel = socket.channel('topic', { one: 'two' })
+  })
+
+  afterEach(async () => {
+    await socket.disconnect()
+    channel.unsubscribe()
   })
 
   it('returns true when socket connected and channel joined', () => {
@@ -642,6 +665,11 @@ describe('on', () => {
     sinon.stub(socket, 'makeRef').callsFake(() => defaultRef)
 
     channel = socket.channel('topic', { one: 'two' })
+  })
+
+  afterEach(async () => {
+    await socket.disconnect()
+    channel.unsubscribe()
   })
 
   it('sets up callback for event', () => {
@@ -697,6 +725,11 @@ describe('off', () => {
     channel = socket.channel('topic', { one: 'two' })
   })
 
+  afterEach(async () => {
+    await socket.disconnect()
+    channel.unsubscribe()
+  })
+
   it('removes all callbacks for event', () => {
     const spy1 = sinon.spy()
     const spy2 = sinon.spy()
@@ -739,8 +772,10 @@ describe('push', () => {
     channel = socket.channel('topic', { one: 'two' })
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     clock.restore()
+    await socket.disconnect()
+    channel.unsubscribe()
   })
 
   it('sends push event when successfully joined', () => {
@@ -840,8 +875,10 @@ describe('leave', () => {
     channel.subscribe().trigger('ok', {})
   })
 
-  afterEach(() => {
+  afterEach(async () => {
     clock.restore()
+    await socket.disconnect()
+    channel.unsubscribe();
   })
 
   it('unsubscribes from server events', () => {

--- a/test/socket_test.js
+++ b/test/socket_test.js
@@ -11,6 +11,10 @@ describe('constructor', () => {
     window.XMLHttpRequest = sinon.useFakeXMLHttpRequest()
   })
 
+  afterEach(async () => {
+    await socket.disconnect()
+  })
+
   after(() => {
     window.XMLHttpRequest = null
   })
@@ -73,6 +77,10 @@ describe('constructor', () => {
         done()
       })
     })
+  
+    afterEach(async () => {
+    await socket.disconnect()
+    })
 
     it('defaults to Websocket transport if available', () => {
       socket = new RealtimeClient('wss://example.com/socket')
@@ -82,6 +90,10 @@ describe('constructor', () => {
 })
 
 describe('endpointURL', () => {
+  afterEach(async () => {
+    await socket.disconnect()
+  })
+
   it('returns endpoint for given full url', () => {
     socket = new RealtimeClient('wss://example.org/chat')
     assert.equal(
@@ -125,6 +137,10 @@ describe('connect with WebSocket', () => {
 
   beforeEach(() => {
     socket = new RealtimeClient('wss://example.com/socket')
+  })
+
+  afterEach(async () => {
+    await socket.disconnect()
   })
 
   it('establishes websocket connection with endpoint', () => {
@@ -195,6 +211,10 @@ describe('disconnect', () => {
     socket = new RealtimeClient('wss://example.com/socket')
   })
 
+  afterEach(async () => {
+    await socket.disconnect()
+  })
+
   it('removes existing connection', () => {
     socket.connect()
     socket.disconnect()
@@ -230,6 +250,10 @@ describe('disconnect', () => {
 describe('connectionState', () => {
   beforeEach(() => {
     socket = new RealtimeClient('wss://example.com/socket')
+  })
+
+  afterEach(async () => {
+    await socket.disconnect()
   })
 
   it('defaults to closed', () => {
@@ -288,6 +312,10 @@ describe('channel', () => {
     socket = new RealtimeClient('wss://example.com/socket')
   })
 
+  afterEach(async () => {
+    await socket.disconnect()
+  })
+
   it('returns channel with given topic and params', () => {
     channel = socket.channel('topic', { one: 'two' })
 
@@ -311,6 +339,10 @@ describe('channel', () => {
 describe('remove', () => {
   beforeEach(() => {
     socket = new RealtimeClient('wss://example.com/socket')
+  })
+
+  afterEach(async () => {
+    await socket.disconnect()
   })
 
   it('removes given channel from channels', () => {
@@ -351,6 +383,10 @@ describe('push', () => {
     socket = new RealtimeClient('wss://example.com/socket')
   })
 
+  afterEach(async () => {
+    await socket.disconnect()
+  })
+
   // TODO: fix for W3CWebSocket
   it.skip('sends data to connection when connected', () => {
     socket.connect()
@@ -388,6 +424,10 @@ describe('makeRef', () => {
     socket = new RealtimeClient('wss://example.com/socket')
   })
 
+  afterEach(async () => {
+    await socket.disconnect()
+  })
+
   it('returns next message ref', () => {
     assert.strictEqual(socket.ref, 0)
     assert.strictEqual(socket.makeRef(), '1')
@@ -416,6 +456,10 @@ describe('sendHeartbeat', () => {
   beforeEach(() => {
     socket = new RealtimeClient('wss://example.com/socket')
     socket.connect()
+  })
+
+  afterEach(async () => {
+    await socket.disconnect()
   })
 
   // TODO: fix for W3CWebSocket
@@ -469,6 +513,10 @@ describe('flushSendBuffer', () => {
     socket.connect()
   })
 
+  afterEach(async () => {
+    await socket.disconnect()
+  })
+
   // TODO: fix for W3CWebSocket
   it.skip('calls callbacks in buffer when connected', () => {
     socket.conn.readyState = 1 // open
@@ -515,6 +563,10 @@ describe('_onConnOpen', () => {
       reconnectAfterMs: () => 100000,
     })
     socket.connect()
+  })
+
+  afterEach(async () => {
+    await socket.disconnect()
   })
 
   // TODO: fix for W3CWebSocket
@@ -569,6 +621,10 @@ describe('_onConnClose', () => {
     socket.connect()
   })
 
+  afterEach(async () => {
+    await socket.disconnect()
+  })
+
   it('schedules reconnectTimer timeout', () => {
     const spy = sinon.spy(socket.reconnectTimer, 'scheduleTimeout')
 
@@ -618,6 +674,10 @@ describe('_onConnError', () => {
     socket.connect()
   })
 
+  afterEach(async () => {
+    await socket.disconnect()
+  })
+
   it('triggers onClose callback', () => {
     const spy = sinon.spy()
 
@@ -657,6 +717,10 @@ describe('onConnMessage', () => {
       reconnectAfterMs: () => 100000,
     })
     socket.connect()
+  })
+
+  afterEach(async () => {
+    await socket.disconnect()
   })
 
   it('parses raw message, resets heartbeat, and triggers channel event', () => {
@@ -709,6 +773,10 @@ describe('onConnMessage', () => {
 })
 
 describe('custom encoder and decoder', () => {
+  afterEach(async () => {
+    await socket.disconnect()
+  })
+
   it('encodes to JSON by default', () => {
     socket = new RealtimeClient('wss://example.com/socket')
     let payload = { foo: 'bar' }


### PR DESCRIPTION
## What kind of change does this PR introduce?

It clears timeouts and intervals when calling `disconnect()`

## What is the current behavior?

When including `realtime-js` as a dependency, there's no way to close timeouts and intervals, leaving open handles.

This project has solved this issue on the tests using a mocha `--exit` flag but that is not an option for downstream modules that want to avoid leaks.

## What is the new behavior?

This PR updates the tests in realtime-js to call `disconnect()` after each test. Users of this module should do the same when testing and cleanly shutting down servers.

## Additional context

This PR should also help fix https://github.com/supabase/supabase-js/issues/44 without `process.exit()` hacks.
