### PR TITLE
feat: update transformers to accept already transformed walrus changes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,9 @@
 {
+  "parser": "babel-eslint",
   "parserOptions": {
-    "ecmaVersion": 6
+    "allowImportExportEverywhere": true,
+    "ecmaVersion": 6,
+    "sourceType": "module"
   },
   "ecmaFeatures": {
     "modules": true

--- a/test/transformers_test.js
+++ b/test/transformers_test.js
@@ -21,6 +21,30 @@ describe('transformers', () => {
       ),
       { first_name: 'Paul', age: 33 }
     )
+
+    assert.deepEqual(
+      convertChangeData(
+        [
+          { name: 'first_name', type: 'text' },
+          { name: 'age', type: 'int4' },
+        ],
+        { first_name: 'Mark', age: 23 },
+        {}
+      ),
+      { first_name: 'Mark', age: 23 }
+    )
+
+    assert.deepEqual(
+      convertChangeData(
+        [
+          { name: 'first_name', type: 'text' },
+          { name: 'age', type: 'int4' },
+        ],
+        { first_name: 'Paul', age: null },
+        {}
+      ),
+      { first_name: 'Paul', age: null }
+    )
   })
 
   it('convertColumn', () => {
@@ -52,7 +76,19 @@ describe('transformers', () => {
 
   it('convertCell', () => {
     assert.strictEqual(convertCell('bool', 't'), true)
+    assert.strictEqual(convertCell('bool', true), true)
+
     assert.strictEqual(convertCell('int8', '10'), 10)
+    assert.strictEqual(convertCell('int8', 10), 10)
+
+    assert.strictEqual(convertCell('numeric', '12345.12345'), 12345.12345)
+    assert.strictEqual(convertCell('numeric', 12345.12345), 12345.12345)
+
+    assert.strictEqual(convertCell('int4range', '[1,10)'), '[1,10)')
+
+    assert.strictEqual(convertCell('float8', null), null)
+
+    assert.strictEqual(convertCell('json', '"[1,2,3]"'), '[1,2,3]')
 
     assert.deepEqual(convertCell('_int4', '{1,2,3,4}'), [1, 2, 3, 4])
   })
@@ -60,6 +96,17 @@ describe('transformers', () => {
   it('toArray', () => {
     assert.deepEqual(toArray('{1,2,3,4}', 'int4'), [1, 2, 3, 4])
     assert.deepEqual(toArray('{}', 'int4'), [])
+    assert.deepEqual(
+      toArray(
+        '{"[2021-01-01,2021-12-31)","(2021-01-01,2021-12-32]"}',
+        'daterange'
+      ),
+      ['[2021-01-01,2021-12-31)', '(2021-01-01,2021-12-32]']
+    )
+    assert.deepEqual(
+      toArray([99, 999, 9999, 99999], 'int8'),
+      [99, 999, 9999, 99999]
+    )
   })
 
   it('toTimestampString', () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature + bug fixes + refactor

- maintains existing output of realtime changes while making it compatible with walrus changes since walrus will pass through, via realtime, the actual values based on data types. For example, instead of delivering `'{1, 2, 3}'` for `_int4` which has to be transformed by clients, realtime is sending `[1, 2, 3]` to clients. See this [PR comment](https://github.com/supabase/walrus/pull/10#discussion_r725268249) for more context.

## What is the current behavior?

- There are a couple of existing issues such as ranges because of Postgres' inclusive and exclusive bounds and splitting on comma in the `toArray` function.

For example when type is `_daterange`:

<img width="1280" alt="Screen Shot 2021-10-14 at 11 48 03 PM" src="https://user-images.githubusercontent.com/5532241/137832741-75c7441f-9131-4819-b770-2be03b0b20ac.png">

## What is the new behavior?

- transformers play nicely with walrus changes as well as existing realtime changes.

## Additional context

- Other client libs copied the transformations from this client so there are bugs in those libs as well. We'll have to notify maintainers of other libs to update their transformations after this is approved.