### PR TITLE
fix: error parsing JSON when transforming array data types

### DIFF
--- a/test/transformers_test.js
+++ b/test/transformers_test.js
@@ -94,8 +94,8 @@ describe('transformers', () => {
   })
 
   it('toArray', () => {
-    assert.deepEqual(toArray('{1,2,3,4}', 'int4'), [1, 2, 3, 4])
     assert.deepEqual(toArray('{}', 'int4'), [])
+    assert.deepEqual(toArray('{1,2,3,4}', 'int4'), [1, 2, 3, 4])
     assert.deepEqual(
       toArray(
         '{"[2021-01-01,2021-12-31)","(2021-01-01,2021-12-32]"}',
@@ -103,6 +103,7 @@ describe('transformers', () => {
       ),
       ['[2021-01-01,2021-12-31)', '(2021-01-01,2021-12-32]']
     )
+    assert.deepEqual(toArray('{a,b,c}', 'text'), ['a', 'b', 'c'])
     assert.deepEqual(
       toArray([99, 999, 9999, 99999], 'int8'),
       [99, 999, 9999, 99999]


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Transforming certain Postgres array types (e.g. `_text`) will raise an error b/c the data received (e.g. `"{a,b,c}"`) cannot be parsed to JSON after replacing the curly brackets with square brackets. 

## What is the new behavior?

This temporary solution will work with all array types like `_daterange` (cannot be split on comma) and `_text` (can be split by comma if there's no existing commas in data).

## Additional context

Related issue: https://github.com/supabase/realtime-js/issues/112
