### PR TITLE
fix: push access token only to joined channels

### DIFF
--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -326,10 +326,12 @@ export default class RealtimeClient {
   setAuth(token: string | null) {
     this.accessToken = token
 
-    this.channels.forEach((channel) =>
-      channel.push(CHANNEL_EVENTS.access_token, {
-        access_token: token,
-      })
+    this.channels.forEach(
+      (channel) =>
+        channel.joinedOnce &&
+        channel.push(CHANNEL_EVENTS.access_token, {
+          access_token: token,
+        })
     )
   }
 

--- a/test/socket_test.js
+++ b/test/socket_test.js
@@ -454,10 +454,17 @@ describe('setAuth', () => {
   })
 
   it('sets access token and pushes it to channels', () => {
-    const channel1 = socket.channel('test-topic1')
-    const channel2 = socket.channel('test-topic2')
+    const channel1 = socket.channel('test-topic')
+    const channel2 = socket.channel('test-topic')
+    const channel3 = socket.channel('test-topic')
+
+    channel1.joinedOnce = true
+    channel2.joinedOnce = false
+    channel3.joinedOnce = true
+
     const stub1 = sinon.stub(channel1, 'push')
     const stub2 = sinon.stub(channel2, 'push')
+    const stub3 = sinon.stub(channel3, 'push')
 
     socket.setAuth('token123')
 
@@ -465,7 +472,10 @@ describe('setAuth', () => {
     assert.ok(stub1.calledWith('access_token', {
       access_token: 'token123',
     }))
-    assert.ok(stub2.calledWith('access_token', {
+    assert.ok(!stub2.calledWith('access_token', {
+      access_token: 'token123',
+    }))
+    assert.ok(stub3.calledWith('access_token', {
       access_token: 'token123',
     }))
   })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`access_token` message is pushed to channels that have not been joined yet.

![image (7)](https://user-images.githubusercontent.com/5532241/142942138-cfdbb9df-f105-43eb-8b5f-4bd6bd56aaa1.png)

## What is the new behavior?

`access_token` message is pushed only to joined channels.
