### PR TITLE
fix: force client to listen to unique subscriptions

### DIFF
--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -339,6 +339,16 @@ export default class RealtimeClient {
     }
   }
 
+  leaveOpenTopic(topic: string): void {
+    let dupChannel = this.channels.find(
+      (c) => c.topic === topic && (c.isJoined() || c.isJoining())
+    )
+    if (dupChannel) {
+      this.log('transport', `leaving duplicate topic "${topic}"`)
+      dupChannel.unsubscribe()
+    }
+  }
+
   private _onConnOpen() {
     this.log('transport', `connected to ${this.endPointURL()}`)
     this._flushSendBuffer()

--- a/src/RealtimeSubscription.ts
+++ b/src/RealtimeSubscription.ts
@@ -163,16 +163,13 @@ export default class RealtimeSubscription {
     return this.joinPush.ref
   }
 
-  sendJoin(timeout: number) {
-    this.state = CHANNEL_STATES.joining
-    this.joinPush.resend(timeout)
-  }
-
   rejoin(timeout = this.timeout) {
     if (this.isLeaving()) {
       return
     }
-    this.sendJoin(timeout)
+    this.socket.leaveOpenTopic(this.topic)
+    this.state = CHANNEL_STATES.joining
+    this.joinPush.resend(timeout)
   }
 
   trigger(event: string, payload?: any, ref?: string) {

--- a/test/channel_test.js
+++ b/test/channel_test.js
@@ -492,6 +492,7 @@ describe('onError', () => {
   })
 
   it('tries to rejoin with backoff', () => {
+    const leaveTopicSpy = sinon.stub(socket, 'leaveOpenTopic')
     const spy = sinon.stub(joinPush, 'send')
 
     assert.equal(spy.callCount, 0)
@@ -509,6 +510,8 @@ describe('onError', () => {
 
     clock.tick(10000)
     assert.equal(spy.callCount, 4)
+
+    assert.equal(leaveTopicSpy.callCount, 4)
   })
 
   it('does not rejoin if channel leaving', () => {

--- a/test/socket_test.js
+++ b/test/socket_test.js
@@ -336,6 +336,31 @@ describe('channel', () => {
   })
 })
 
+describe('leaveOpenTopic', () => {
+  let channel1
+  let channel2
+
+  beforeEach(() => {
+    socket = new RealtimeClient('wss://example.com/socket')
+  })
+
+  afterEach(async () => {
+    channel1.unsubscribe()
+    channel2.unsubscribe()
+    await socket.disconnect()
+  })
+
+  it('enforces client to subscribe to unique topics', () => {
+    channel1 = socket.channel('topic', { one: 'two' })
+    channel2 = socket.channel('topic', { one: 'two' })
+    channel1.subscribe()
+    channel2.subscribe()
+
+    assert.equal(socket.channels.length, 1)
+    assert.equal(socket.channels[0].topic, 'topic')
+  })
+})
+
 describe('remove', () => {
   beforeEach(() => {
     socket = new RealtimeClient('wss://example.com/socket')


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Client can create duplicate subscriptions by listening to the same topic.

## What is the new behavior?

Client can create one subscription for each unique topic.

## Additional context

Fixes: https://github.com/supabase/realtime-js/issues/127
