### PR TITLE
fix: set heartbeat ref to null on incoming message

### DIFF
--- a/test/socket_test.js
+++ b/test/socket_test.js
@@ -795,7 +795,7 @@ describe('onConnMessage', () => {
     await socket.disconnect()
   })
 
-  it('parses raw message, resets heartbeat, and triggers channel event', () => {
+  it('parses raw message and triggers channel event', () => {
     const message =
       '{"topic":"topic","event":"INSERT","payload":{"type":"INSERT"},"ref":"ref"}'
     const data = { data: message }
@@ -806,21 +806,13 @@ describe('onConnMessage', () => {
     const targetSpy = sinon.spy(targetChannel, 'trigger')
     const otherSpy = sinon.spy(otherChannel, 'trigger')
 
-    const prevIntervalId = setInterval(() => {}, 0)[Symbol.toPrimitive]()
-
     socket.pendingHeartbeatRef = '3'
-    socket.heartbeatTimer = prevIntervalId
-
     socket.onConnMessage(data)
-
-    const newIntervalId = socket.heartbeatTimer[Symbol.toPrimitive]()
 
     assert.ok(targetSpy.calledWith('INSERT', {type: 'INSERT'}, 'ref'))
     assert.strictEqual(targetSpy.callCount, 1)
     assert.strictEqual(otherSpy.callCount, 0)
     assert.strictEqual(socket.pendingHeartbeatRef, null)
-    assert.strictEqual(typeof newIntervalId, 'number')
-    assert.notStrictEqual(newIntervalId, prevIntervalId)
   })
 
   it('triggers onMessage callback', () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

client resets heartbeat message send interval on received message so another heartbeat message is not sent to server. this results in reconnection and lost database change messages when server has reached socket connection timeout limit.

## What is the new behavior?

client resets pendingHeartbeatRef to `null` but will not reset heartbeat message send interval so client continues to send heartbeat message at a regular interval.

## Additional context

Related issues:

- https://github.com/supabase/realtime-js/issues/94
- https://github.com/supabase/supabase/issues/5290#issuecomment-1045121578
- https://github.com/supabase/realtime-js/issues/133
