### PR TITLE
fix: remove lodash clonedeep and isequal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@types/phoenix": "^1.5.4",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.isequal": "^4.5.0",
         "websocket": "^1.0.34"
       },
       "devDependencies": {
         "@babel/runtime": "^7.9.2",
-        "@types/lodash.clonedeep": "^4.5.6",
-        "@types/lodash.isequal": "^4.5.5",
         "@types/websocket": "^1.0.3",
         "babel-preset-env": "^1.7.0",
         "babel-register": "^6.26.0",
@@ -258,30 +254,6 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.14.178",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
-      "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==",
-      "dev": true
-    },
-    "node_modules/@types/lodash.clonedeep": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
-      "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
-    },
-    "node_modules/@types/lodash.isequal": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.5.tgz",
-      "integrity": "sha512-4IKbinG7MGP131wRfceK6W4E/Qt3qssEFLF30LnJbjYiSfHGGRU/Io8YxXrZX109ir+iDETC8hw8QsDijukUVg==",
-      "dev": true,
-      "dependencies": {
-        "@types/lodash": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "17.0.23",
@@ -3185,21 +3157,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "node_modules/lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
-    },
-    "node_modules/lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -5695,30 +5657,6 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
-    "@types/lodash": {
-      "version": "4.14.178",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.178.tgz",
-      "integrity": "sha512-0d5Wd09ItQWH1qFbEyQ7oTQ3GZrMfth5JkbN3EvTKLXcHLRDSXeLnlvlOn0wvxVIwK5o2M8JzP/OWz7T3NRsbw==",
-      "dev": true
-    },
-    "@types/lodash.clonedeep": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
-      "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
-    "@types/lodash.isequal": {
-      "version": "4.5.5",
-      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.5.tgz",
-      "integrity": "sha512-4IKbinG7MGP131wRfceK6W4E/Qt3qssEFLF30LnJbjYiSfHGGRU/Io8YxXrZX109ir+iDETC8hw8QsDijukUVg==",
-      "dev": true,
-      "requires": {
-        "@types/lodash": "*"
-      }
-    },
     "@types/node": {
       "version": "17.0.23",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.23.tgz",
@@ -8092,21 +8030,11 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
-    },
-    "lodash.isequal": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -36,14 +36,10 @@
   },
   "dependencies": {
     "@types/phoenix": "^1.5.4",
-    "lodash.clonedeep": "^4.5.0",
-    "lodash.isequal": "^4.5.0",
     "websocket": "^1.0.34"
   },
   "devDependencies": {
     "@babel/runtime": "^7.9.2",
-    "@types/lodash.clonedeep": "^4.5.6",
-    "@types/lodash.isequal": "^4.5.5",
     "@types/websocket": "^1.0.3",
     "babel-preset-env": "^1.7.0",
     "babel-register": "^6.26.0",

--- a/src/RealtimeChannel.ts
+++ b/src/RealtimeChannel.ts
@@ -1,4 +1,3 @@
-import isEqual from 'lodash.isequal'
 import { CHANNEL_EVENTS, CHANNEL_STATES } from './lib/constants'
 import Push from './lib/push'
 import RealtimeClient from './RealtimeClient'
@@ -127,7 +126,10 @@ export default class RealtimeChannel {
 
   off(type: string, eventFilter: { [key: string]: any }) {
     this.bindings = this.bindings.filter((bind) => {
-      return !(bind.type === type && isEqual(bind.eventFilter, eventFilter))
+      return !(
+        bind.type === type &&
+        RealtimeChannel.isEqual(bind.eventFilter, eventFilter)
+      )
     })
   }
 
@@ -258,5 +260,22 @@ export default class RealtimeChannel {
   }
   isLeaving() {
     return this.state === CHANNEL_STATES.leaving
+  }
+
+  private static isEqual(
+    obj1: { [key: string]: string },
+    obj2: { [key: string]: string }
+  ) {
+    if (Object.keys(obj1).length !== Object.keys(obj2).length) {
+      return false
+    }
+
+    for (const k in obj1) {
+      if (obj1[k] !== obj2[k]) {
+        return false
+      }
+    }
+
+    return true
   }
 }

--- a/src/RealtimePresence.ts
+++ b/src/RealtimePresence.ts
@@ -3,7 +3,6 @@
   License: https://github.com/phoenixframework/phoenix/blob/d344ec0a732ab4ee204215b31de69cf4be72e3bf/LICENSE.md
 */
 
-import cloneDeep from 'lodash.clonedeep'
 import {
   PresenceOpts,
   PresenceOnJoinCallback,
@@ -123,7 +122,7 @@ export default class RealtimePresence {
     onJoin: PresenceOnJoinCallback,
     onLeave: PresenceOnLeaveCallback
   ): PresenceState {
-    const state = cloneDeep(currentState)
+    const state = this.cloneDeep(currentState)
     const transformedState = this.transformState(newState)
     const joins: PresenceState = {}
     const leaves: PresenceState = {}
@@ -192,7 +191,7 @@ export default class RealtimePresence {
 
     this.map(joins, (key, newPresences: Presence[]) => {
       const currentPresences: Presence[] = state[key]
-      state[key] = cloneDeep(newPresences)
+      state[key] = this.cloneDeep(newPresences)
 
       if (currentPresences) {
         const joinedPresenceIds = state[key].map((m: Presence) => m.presence_id)
@@ -275,7 +274,7 @@ export default class RealtimePresence {
   private static transformState(
     state: RawPresenceState | PresenceState
   ): PresenceState {
-    state = cloneDeep(state)
+    state = this.cloneDeep(state)
 
     return Object.getOwnPropertyNames(state).reduce((newState, key) => {
       const presences = state[key]
@@ -295,6 +294,10 @@ export default class RealtimePresence {
 
       return newState
     }, {} as PresenceState)
+  }
+
+  private static cloneDeep(obj: object) {
+    return JSON.parse(JSON.stringify(obj))
   }
 
   onJoin(callback: PresenceOnJoinCallback): void {

--- a/test/presence_test.js
+++ b/test/presence_test.js
@@ -4,8 +4,15 @@
 */
 
 import assert from 'assert'
-import cloneDeep from 'lodash.clonedeep'
 import { RealtimePresence } from '../dist/main'
+
+const cloneDeep = (obj) => {
+  const cloned = JSON.parse(JSON.stringify(obj))
+  Object.entries(obj).map(([key, val]) => {
+    if(val === undefined){ cloned[key] = undefined }
+  })
+  return cloned
+}
 
 const fixtures = {
   joins() {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Lodash methods do not work with Nuxt 3 out of the box.

## What is the new behavior?

Removing Lodash methods and replace them with vanilla JS.

## Additional context

- https://github.com/supabase/realtime-js/issues/148
- https://github.com/supabase/realtime-js/issues/149

