### PR TITLE
fix: use JSON.stringify to flatten deep objects for comparisons within isEqual

### DIFF
--- a/src/RealtimeChannel.ts
+++ b/src/RealtimeChannel.ts
@@ -116,7 +116,11 @@ export default class RealtimeChannel {
     this.on(CHANNEL_EVENTS.error, {}, (reason: string) => callback(reason))
   }
 
-  on(type: string, eventFilter?: { [key: string]: string }, callback?: Function) {
+  on(
+    type: string,
+    eventFilter?: { [key: string]: string },
+    callback?: Function
+  ) {
     this.bindings.push({
       type,
       eventFilter: eventFilter ?? {},
@@ -270,12 +274,6 @@ export default class RealtimeChannel {
       return false
     }
 
-    for (const k in obj1) {
-      if (obj1[k] !== obj2[k]) {
-        return false
-      }
-    }
-
-    return true
+    return JSON.stringify(obj1) === JSON.stringify(obj2)
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?
https://github.com/supabase/realtime-js/pull/150 was merged while I was just working on a similar one.

Ensures accurate comparisons from isEqual

Bug fix, feature, docs update, ...

## What is the current behavior?
isEqual fails on array comparisons with same values but different references. Deep nested comparisons fail

Please link any relevant issues here.
https://replit.com/@sduduzog/jest-playground In ths repl, a single unit test is ran for a lodash isEqual, the current one and the incoming one from this PR. The test was sourced from here: https://github.com/lodash/lodash/blob/master/test/isEqual.js

## What is the new behavior?
Pretty much the same as https://github.com/supabase/realtime-js/pull/150

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
