### PR TITLE
feat: use channel or subscription depending on versionDate

### DIFF
--- a/src/RealtimeChannel.ts
+++ b/src/RealtimeChannel.ts
@@ -122,19 +122,18 @@ export default class RealtimeChannel {
     this.on(CHANNEL_EVENTS.error, {}, (reason: string) => callback(reason))
   }
 
-  on(type: string, eventFilter?: { [key: string]: string }, callback?: Function) {
+  on(type: string, filter?: { [key: string]: string }, callback?: Function) {
     this.bindings.push({
       type,
-      eventFilter: eventFilter ?? {},
+      filter: filter ?? {},
       callback: callback ?? (() => {}),
     })
   }
 
-  off(type: string, eventFilter: { [key: string]: any }) {
+  off(type: string, filter: { [key: string]: any }) {
     this.bindings = this.bindings.filter((bind) => {
       return !(
-        bind.type === type &&
-        RealtimeChannel.isEqual(bind.eventFilter, eventFilter)
+        bind.type === type && RealtimeChannel.isEqual(bind.filter, filter)
       )
     })
   }
@@ -235,8 +234,8 @@ export default class RealtimeChannel {
       .filter((bind) => {
         return (
           bind?.type === type &&
-          (bind?.eventFilter?.event === '*' ||
-            bind?.eventFilter?.event === payload?.event)
+          (bind?.filter?.event === '*' ||
+            bind?.filter?.event === payload?.event)
         )
       })
       .map((bind) => bind.callback(handledPayload, ref))

--- a/test/presence_test.js
+++ b/test/presence_test.js
@@ -41,7 +41,7 @@ const channelStub = {
   ref: 1,
   events: {},
 
-  on(event, _eventFilter, callback) {
+  on(event, _filter, callback) {
     this.events[event] = callback
   },
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Use `vsndate` url query params to determine whether to instantiate RealtimeSubscription or RealtimeChannel.
