### PR TITLE
fix: update logic that sets versionDate in RealtimeClient instance

### DIFF
--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -143,7 +143,7 @@ export default class RealtimeClient {
         new URL(this.conn.url).searchParams.get('vsndate') ?? ''
       )
 
-      if (versionDate instanceof Date) {
+      if (versionDate.toString() !== 'Invalid Date') {
         this.versionDate = versionDate
       }
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the new behavior?

this.versionDate is only set when `vsndate` query param is a valid date.
