### PR TITLE
fix: remove URL instance with vsndate from params

### DIFF
--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -72,7 +72,6 @@ export default class RealtimeClient {
     error: [],
     message: [],
   }
-  versionDate: Date | undefined = undefined
 
   /**
    * Initializes the Socket.
@@ -138,14 +137,6 @@ export default class RealtimeClient {
       this.conn.onerror = (error) => this._onConnError(error as ErrorEvent)
       this.conn.onmessage = (event) => this.onConnMessage(event)
       this.conn.onclose = (event) => this._onConnClose(event)
-
-      const versionDate = new Date(
-        new URL(this.conn.url).searchParams.get('vsndate') ?? ''
-      )
-
-      if (versionDate.toString() !== 'Invalid Date') {
-        this.versionDate = versionDate
-      }
     }
   }
 
@@ -277,11 +268,12 @@ export default class RealtimeClient {
     chanParams: ChannelParams = {}
   ): RealtimeChannel | RealtimeSubscription {
     const { selfBroadcast, ...params } = chanParams
+
     if (selfBroadcast) {
       params.self_broadcast = selfBroadcast
     }
 
-    const chan = this.versionDate
+    const chan = this.params?.vsndate
       ? new RealtimeChannel(topic, params, this)
       : new RealtimeSubscription(topic, params, this)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Use of `URL` to get `vsndate` query param is broken in React Native since URL needs a polyfill.

## What is the new behavior?

Just works.

## Additional context

Related discussion: https://github.com/supabase/supabase/discussions/6522#discussioncomment-2616398
