### PR TITLE
fix: keep second channel with same topic open on rapid re-subscribe

### DIFF
--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -30,6 +30,7 @@ type Message = {
   event: string
   payload: any
   ref: string
+  join_ref?: string
 }
 
 type ChannelParams = {

--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -51,6 +51,7 @@ export default class Push {
       event: this.event,
       payload: this.payload,
       ref: this.ref,
+      join_ref: this.channel.joinRef(),
     })
   }
 

--- a/test/channel_test.js
+++ b/test/channel_test.js
@@ -5,7 +5,7 @@ import { RealtimeSubscription, RealtimeClient } from '../dist/main'
 
 let channel, socket
 
-const defaultRef = 1
+const defaultRef = '1'
 const defaultTimeout = 10000
 
 describe('constructor', () => {
@@ -87,6 +87,7 @@ describe('join', () => {
         event: 'phx_join',
         payload: { one: 'two' },
         ref: defaultRef,
+        join_ref: defaultRef
       })
     )
   })
@@ -781,6 +782,7 @@ describe('push', () => {
     event: 'event',
     payload: { foo: 'bar' },
     ref: defaultRef,
+    join_ref: defaultRef
   }
 
   beforeEach(() => {
@@ -914,6 +916,7 @@ describe('leave', () => {
         event: 'phx_leave',
         payload: {},
         ref: defaultRef,
+        join_ref: defaultRef
       })
     )
   })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Devs who are using React 18 in strict mode in development are having their subscriptions closed.

## What is the new behavior?

Devs who are using React 18 in strict mode in development are able to maintain a joined and open subscription.

## Additional context

Addresses: https://github.com/supabase/realtime-js/issues/169

This is a cherry pick from `rc` branch: https://github.com/supabase/realtime-js/commit/c32db96f87023dceaaccc5f081e0bda5c5e5b9be