### PR TITLE
fix: improve realtime postgres changes types

### DIFF
--- a/src/RealtimeChannel.ts
+++ b/src/RealtimeChannel.ts
@@ -24,17 +24,44 @@ export type RealtimeChannelOptions = {
   }
 }
 
-export type RealtimePostgresChangesPayload<T extends { [key: string]: any }> = {
+type RealtimePostgresChangesPayloadBase = {
   schema: string
   table: string
   commit_timestamp: string
-  eventType:
-    | `${REALTIME_POSTGRES_CHANGES_LISTEN_EVENT.INSERT}`
-    | `${REALTIME_POSTGRES_CHANGES_LISTEN_EVENT.UPDATE}`
-    | `${REALTIME_POSTGRES_CHANGES_LISTEN_EVENT.DELETE}`
-  new: T | {}
-  old: Partial<T> | {}
   errors: string[]
+}
+
+export type RealtimePostgresInsertPayload<T extends { [key: string]: any }> =
+  RealtimePostgresChangesPayloadBase & {
+    eventType: `${REALTIME_POSTGRES_CHANGES_LISTEN_EVENT.INSERT}`
+    new: T
+    old: {}
+  }
+
+export type RealtimePostgresUpdatePayload<T extends { [key: string]: any }> =
+  RealtimePostgresChangesPayloadBase & {
+    eventType: `${REALTIME_POSTGRES_CHANGES_LISTEN_EVENT.UPDATE}`
+    new: T
+    old: Partial<T>
+  }
+
+export type RealtimePostgresDeletePayload<T extends { [key: string]: any }> =
+  RealtimePostgresChangesPayloadBase & {
+    eventType: `${REALTIME_POSTGRES_CHANGES_LISTEN_EVENT.DELETE}`
+    new: {}
+    old: Partial<T>
+  }
+
+export type RealtimePostgresChangesPayload<T extends { [key: string]: any }> =
+  | RealtimePostgresInsertPayload<T>
+  | RealtimePostgresUpdatePayload<T>
+  | RealtimePostgresDeletePayload<T>
+
+type RealtimePostgresChangesFilter<T extends string> = {
+  event: T
+  schema: string
+  table?: string
+  filter?: string
 }
 
 export type RealtimeChannelSendResponse = 'ok' | 'timed out' | 'rate limited'
@@ -288,23 +315,38 @@ export default class RealtimeChannel {
   ): RealtimeChannel
   on(
     type: `${REALTIME_LISTEN_TYPES.PRESENCE}`,
-    filter: { event: `${REALTIME_PRESENCE_LISTEN_EVENTS}` },
-    callback: (
-      payload:
-        | RealtimePresenceJoinPayload
-        | RealtimePresenceLeavePayload
-        | undefined
-    ) => void
+    filter: { event: `${REALTIME_PRESENCE_LISTEN_EVENTS.SYNC}` },
+    callback: () => void
+  ): RealtimeChannel
+  on(
+    type: `${REALTIME_LISTEN_TYPES.PRESENCE}`,
+    filter: { event: `${REALTIME_PRESENCE_LISTEN_EVENTS.JOIN}` },
+    callback: (payload: RealtimePresenceJoinPayload) => void
+  ): RealtimeChannel
+  on(
+    type: `${REALTIME_LISTEN_TYPES.PRESENCE}`,
+    filter: { event: `${REALTIME_PRESENCE_LISTEN_EVENTS.LEAVE}` },
+    callback: (payload: RealtimePresenceLeavePayload) => void
   ): RealtimeChannel
   on<T extends { [key: string]: any }>(
     type: `${REALTIME_LISTEN_TYPES.POSTGRES_CHANGES}`,
-    filter: {
-      event: `${REALTIME_POSTGRES_CHANGES_LISTEN_EVENT}`
-      schema: string
-      table?: string
-      filter?: string
-    },
+    filter: RealtimePostgresChangesFilter<`${REALTIME_POSTGRES_CHANGES_LISTEN_EVENT.ALL}`>,
     callback: (payload: RealtimePostgresChangesPayload<T>) => void
+  ): RealtimeChannel
+  on<T extends { [key: string]: any }>(
+    type: `${REALTIME_LISTEN_TYPES.POSTGRES_CHANGES}`,
+    filter: RealtimePostgresChangesFilter<`${REALTIME_POSTGRES_CHANGES_LISTEN_EVENT.INSERT}`>,
+    callback: (payload: RealtimePostgresInsertPayload<T>) => void
+  ): RealtimeChannel
+  on<T extends { [key: string]: any }>(
+    type: `${REALTIME_LISTEN_TYPES.POSTGRES_CHANGES}`,
+    filter: RealtimePostgresChangesFilter<`${REALTIME_POSTGRES_CHANGES_LISTEN_EVENT.UPDATE}`>,
+    callback: (payload: RealtimePostgresUpdatePayload<T>) => void
+  ): RealtimeChannel
+  on<T extends { [key: string]: any }>(
+    type: `${REALTIME_LISTEN_TYPES.POSTGRES_CHANGES}`,
+    filter: RealtimePostgresChangesFilter<`${REALTIME_POSTGRES_CHANGES_LISTEN_EVENT.DELETE}`>,
+    callback: (payload: RealtimePostgresDeletePayload<T>) => void
   ): RealtimeChannel
   on(
     type: `${REALTIME_LISTEN_TYPES}`,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Types improvement

## What is the current behavior?

Incomplete types for postgres changes events.

Example from Redux Toolkit (inside the `onCacheEntryAdded` callback)

```ts
const channel = supabase
  .channel('db-messages')
  .on<Post>(
    'postgres_changes',
    { event: '*', schema: 'public', table: 'posts' },
    (payload) =>
      updateCachedData((draft) => {
        if (payload.eventType === 'INSERT') {
          postsAdapter.addOne(draft, payload.new);
          // Argument of type '{} | Post' is not assignable to parameter of type 'Post'.
        }

        if (payload.eventType === 'UPDATE') {
          postsAdapter.updateOne(draft, {
            id: payload.new.id, // Property 'id' does not exist on type '{} | Post'.
            changes: payload.new,
          });
        }

        if (payload.eventType === 'DELETE') {
          postsAdapter.removeOne(draft, payload.old.id);
          // Property 'id' does not exist on type '{} | Partial<Post>'.
        }
      }),
  )
  .subscribe();
```

## What is the new behavior?

Correct types for presence events and postgres changes events:

```ts
type Post = {}
const channel: RealtimeChannel = {} as any

channel.on('broadcast', { event: 'cursor-pos' }, (payload) => {})

channel.on('presence', { event: 'sync' }, () => {})
channel.on('presence', { event: 'join' }, (payload) => {
  // payload - RealtimePresenceJoinPayload
})
channel.on('presence', { event: 'leave' }, (payload) => {
  // payload - RealtimePresenceLeavePayload
})

channel.on<Post>(
  'postgres_changes',
  { event: '*', schema: 'public' },
  (payload) => {
    // payload - RealtimePostgresChangesPayload<Post>

    if (payload.eventType === 'INSERT') {
      // payload - RealtimePostgresInsertPayload<Post>
    }

    if (payload.eventType === 'UPDATE') {
      // payload - RealtimePostgresUpdatePayload<Post>
    }

    if (payload.eventType === 'DELETE') {
      // payload - RealtimePostgresDeletePayload<Post>
    }
  }
)
channel.on<Post>(
  'postgres_changes',
  { event: 'INSERT', schema: 'public' },
  (payload) => {
    // payload - RealtimePostgresInsertPayload<Post>
  }
)

channel.on<Post>(
  'postgres_changes',
  { event: 'UPDATE', schema: 'public' },
  (payload) => {
    // payload - RealtimePostgresUpdatePayload<Post>
  }
)

channel.on<Post>(
  'postgres_changes',
  { event: 'DELETE', schema: 'public' },
  (payload) => {
    // payload - RealtimePostgresDeletePayload<Post>
  }
)
```
