### PR TITLE
Added @internal flag to ignore private methods into TypeDocs/ Added method comments.

### DIFF
--- a/src/RealtimeChannel.ts
+++ b/src/RealtimeChannel.ts
@@ -59,6 +59,11 @@ export enum REALTIME_SUBSCRIBE_STATES {
   CHANNEL_ERROR = 'CHANNEL_ERROR',
 }
 
+/** A channel is the basic building block of Realtime
+ * It narrows the scope of data flow to subscribed clients.
+ * You can think of a channel as a chatroom where participants are able to see who's online
+ * and send and receive messages; similar to a Discord or Slack channel.
+ **/
 export default class RealtimeChannel {
   bindings: {
     [key: string]: {
@@ -76,6 +81,8 @@ export default class RealtimeChannel {
   pushBuffer: Push[] = []
   presence: RealtimePresence
 
+  /* Topic name can be any string.
+   */
   constructor(
     public topic: string,
     public params: RealtimeChannelOptions = { config: {} },
@@ -134,6 +141,8 @@ export default class RealtimeChannel {
     this.presence = new RealtimePresence(this)
   }
 
+  /* Subscribe registers your client with the server
+   */
   subscribe(
     callback?: (status: `${REALTIME_SUBSCRIBE_STATES}`, err?: Error) => void,
     timeout = this.timeout
@@ -277,6 +286,9 @@ export default class RealtimeChannel {
     )
   }
 
+  /**
+   *   Listen to messages.
+   */
   on(
     type: `${REALTIME_LISTEN_TYPES.BROADCAST}`,
     filter: { event: string },
@@ -388,6 +400,7 @@ export default class RealtimeChannel {
       }
     })
   }
+  /** @internal */
 
   _push(
     event: string,
@@ -413,18 +426,22 @@ export default class RealtimeChannel {
    *
    * Receives all events for specialized message handling before dispatching to the channel callbacks.
    * Must return the payload, modified or unmodified.
+   * @internal
    */
   _onMessage(_event: string, payload: any, _ref?: string) {
     return payload
   }
 
+  /** @internal */
   _isMember(topic: string): boolean {
     return this.topic === topic
   }
+  /** @internal */
 
   _joinRef(): string {
     return this.joinPush.ref
   }
+  /** @internal */
 
   _trigger(type: string, payload?: any, ref?: string) {
     const typeLower = type.toLocaleLowerCase()
@@ -497,23 +514,32 @@ export default class RealtimeChannel {
         })
     }
   }
+  /** @internal */
 
   _isClosed(): boolean {
     return this.state === CHANNEL_STATES.closed
   }
+  /** @internal */
+
   _isJoined(): boolean {
     return this.state === CHANNEL_STATES.joined
   }
+  /** @internal */
+
   _isJoining(): boolean {
     return this.state === CHANNEL_STATES.joining
   }
+  /** @internal */
+
   _isLeaving(): boolean {
     return this.state === CHANNEL_STATES.leaving
   }
+  /** @internal */
 
   _replyEventName(ref: string): string {
     return `chan_reply_${ref}`
   }
+  /** @internal */
 
   _on(type: string, filter: { [key: string]: any }, callback: Function) {
     const typeLower = type.toLocaleLowerCase()
@@ -532,6 +558,7 @@ export default class RealtimeChannel {
 
     return this
   }
+  /** @internal */
 
   _off(type: string, filter: { [key: string]: any }) {
     const typeLower = type.toLocaleLowerCase()
@@ -544,6 +571,7 @@ export default class RealtimeChannel {
     })
     return this
   }
+  /** @internal */
 
   private static isEqual(
     obj1: { [key: string]: string },
@@ -562,6 +590,7 @@ export default class RealtimeChannel {
     return true
   }
 
+  /** @internal */
   private _rejoinUntilConnected() {
     this.rejoinTimer.scheduleTimeout()
     if (this.socket.isConnected()) {
@@ -571,6 +600,7 @@ export default class RealtimeChannel {
 
   /**
    * Registers a callback that will be executed when the channel closes.
+   * @internal
    */
   private _onClose(callback: Function) {
     this._on(CHANNEL_EVENTS.close, {}, callback)
@@ -578,6 +608,7 @@ export default class RealtimeChannel {
 
   /**
    * Registers a callback that will be executed when the channel encounteres an error.
+   * @internal
    */
   private _onError(callback: Function) {
     this._on(CHANNEL_EVENTS.error, {}, (reason: string) => callback(reason))
@@ -585,11 +616,13 @@ export default class RealtimeChannel {
 
   /**
    * Returns `true` if the socket is connected and the channel has been joined.
+   * @internal
    */
   private _canPush(): boolean {
     return this.socket.isConnected() && this._isJoined()
   }
 
+  /** @internal */
   private _rejoin(timeout = this.timeout): void {
     if (this._isLeaving()) {
       return
@@ -599,6 +632,7 @@ export default class RealtimeChannel {
     this.joinPush.resend(timeout)
   }
 
+  /** @internal */
   private _getPayloadRecords(payload: any) {
     const records = {
       new: {},

--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -274,6 +274,7 @@ export default class RealtimeClient {
 
   /**
    * Return the next message ref, accounting for overflows
+   * @internal
    */
   _makeRef(): string {
     let newRef = this.ref + 1
@@ -288,6 +289,7 @@ export default class RealtimeClient {
 
   /**
    * Unsubscribe from channels with the specified topic.
+   * @internal
    */
   _leaveOpenTopic(topic: string): void {
     let dupChannel = this.channels.find(
@@ -303,6 +305,7 @@ export default class RealtimeClient {
    * Removes a subscription from the socket.
    *
    * @param channel An open subscription.
+   * @internal
    */
   _remove(channel: RealtimeChannel) {
     this.channels = this.channels.filter(
@@ -312,6 +315,7 @@ export default class RealtimeClient {
 
   /**
    * Returns the URL of the websocket.
+   * @internal
    */
   private _endPointURL(): string {
     return this._appendParams(
@@ -320,6 +324,7 @@ export default class RealtimeClient {
     )
   }
 
+  /** @internal */
   private _onConnMessage(rawMessage: { data: any }) {
     this.decode(rawMessage.data, (msg: RealtimeMessage) => {
       let { topic, event, payload, ref } = msg
@@ -347,6 +352,7 @@ export default class RealtimeClient {
     })
   }
 
+  /** @internal */
   private _onConnOpen() {
     this.log('transport', `connected to ${this._endPointURL()}`)
     this._flushSendBuffer()
@@ -359,6 +365,7 @@ export default class RealtimeClient {
     this.stateChangeCallbacks.open.forEach((callback) => callback())!
   }
 
+  /** @internal */
   private _onConnClose(event: any) {
     this.log('transport', 'close', event)
     this._triggerChanError()
@@ -367,18 +374,21 @@ export default class RealtimeClient {
     this.stateChangeCallbacks.close.forEach((callback) => callback(event))
   }
 
+  /** @internal */
   private _onConnError(error: ErrorEvent) {
     this.log('transport', error.message)
     this._triggerChanError()
     this.stateChangeCallbacks.error.forEach((callback) => callback(error))
   }
 
+  /** @internal */
   private _triggerChanError() {
     this.channels.forEach((channel: RealtimeChannel) =>
       channel._trigger(CHANNEL_EVENTS.error)
     )
   }
 
+  /** @internal */
   private _appendParams(
     url: string,
     params: { [key: string]: string }
@@ -392,13 +402,14 @@ export default class RealtimeClient {
     return `${url}${prefix}${query}`
   }
 
+  /** @internal */
   private _flushSendBuffer() {
     if (this.isConnected() && this.sendBuffer.length > 0) {
       this.sendBuffer.forEach((callback) => callback())
       this.sendBuffer = []
     }
   }
-
+  /** @internal */
   private _sendHeartbeat() {
     if (!this.isConnected()) {
       return
@@ -422,6 +433,7 @@ export default class RealtimeClient {
     this.setAuth(this.accessToken)
   }
 
+  /** @internal */
   private _throttle(
     callback: Function,
     eventsPerSecondLimit: number = this.eventsPerSecondLimitMs

--- a/src/RealtimePresence.ts
+++ b/src/RealtimePresence.ts
@@ -159,6 +159,7 @@ export default class RealtimePresence {
    * An optional `onJoin` and `onLeave` callback can be provided to
    * react to changes in the client's local presences across
    * disconnects and reconnects with the server.
+   * @internal
    */
   private static syncState(
     currentState: RealtimePresenceState,
@@ -216,6 +217,8 @@ export default class RealtimePresence {
    * Like `syncState`, `syncDiff` accepts optional `onJoin` and
    * `onLeave` callbacks to react to a user joining or leaving from a
    * device.
+   *
+   *   @internal
    */
   private static syncDiff(
     state: RealtimePresenceState,
@@ -276,6 +279,7 @@ export default class RealtimePresence {
     return state
   }
 
+  /** @internal */
   private static map<T = any>(
     obj: RealtimePresenceState,
     func: PresenceChooser<T>
@@ -303,6 +307,7 @@ export default class RealtimePresence {
    *    ]
    *  }
    * })
+   *  @internal
    */
   private static transformState(
     state: RawPresenceState | RealtimePresenceState
@@ -329,21 +334,27 @@ export default class RealtimePresence {
     }, {} as RealtimePresenceState)
   }
 
+  /** @internal */
+
   private static cloneDeep(obj: { [key: string]: any }) {
     return JSON.parse(JSON.stringify(obj))
   }
 
+  /** @internal */
   private onJoin(callback: PresenceOnJoinCallback): void {
     this.caller.onJoin = callback
   }
+  /** @internal */
 
   private onLeave(callback: PresenceOnLeaveCallback): void {
     this.caller.onLeave = callback
   }
+  /** @internal */
 
   private onSync(callback: () => void): void {
     this.caller.onSync = callback
   }
+  /** @internal */
 
   private inPendingSyncState(): boolean {
     return !this.joinRef || this.joinRef !== this.channel._joinRef()


### PR DESCRIPTION
## What kind of change does this PR introduce?
Added comments to methods and added @internal to ignore private methods in documentation.

## What is the current behavior?
Run command `yarn docs`. This command will create v2 version document. 
The document includes internal/private methods - thus making it hard to read.

## What is the new behavior?
Run `yarn docs.` This should hide internal/private methods and show comments to method.

## Additional context

Add any other context or screenshots.
