### PR TITLE
Realtime removeChannel e.unsubscribe is not a function

### DIFF
--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -166,11 +166,15 @@ export default class RealtimeClient {
   removeChannel(
     channel: RealtimeChannel
   ): Promise<RealtimeRemoveChannelResponse> {
-    return channel.unsubscribe().then((status) => {
-      if (this.channels.length === 0) {
-        this.disconnect()
-      }
-      return status
+    return Promise.all(
+      this.channels.filter((item_channel)=>{
+        if(channel.topic === `realtime:${item_channel}`){
+          return channel.unsubscribe()
+        }
+      })
+    ).then((value) => {
+      this.disconnect()
+      return value
     })
   }
 


### PR DESCRIPTION
## Realtime removeChannel e.unsubscribe is not a function

supabase.removeChannel() is showing the error: e.unsubscribe is not a function

Solution from global scope:

```javascript
supabase.removeChannel = function(channel){
  supabase.realtime.channels.map(function (e) {
	if(e.topic === `realtime:${channel}`){
		e.unsubscribe();
	}
  })
}
```

![imagen_2022-11-02_174044711](https://user-images.githubusercontent.com/42706176/199607838-77b43fa1-5cf2-4256-9064-fd595c2d0f2a.png)

