### PR TITLE
docs: add jsdoc for the widely used methods

### DIFF
--- a/src/RealtimeChannel.ts
+++ b/src/RealtimeChannel.ts
@@ -311,7 +311,19 @@ export default class RealtimeChannel {
     )
   }
 
-  /** Listen to messages. */
+  /**
+   * Creates an event handler that listens to changes
+   * @param type Realtime feature (broadcast, presence, or postgres_changes)
+   * @param filter Pre-defined and custom values specific to the Realtime feature
+   * @param filter.schema Database schema
+   * @param filter.event Event to listen to. If listening to postgres_changes type
+   * then this value is one of INSERT, UPDATE, DELETE, *
+   * @param filter.filter If listening to postgres_changes type then this value is used to specify
+   * the Postgres Changes filter (eq, neq, lt, lte, gt, or gte) and value to listen to
+   * @param filter.table If listening to postgres_changes type then this value is used to specify
+   * the database table to listen to
+   * @param callback Function to be invoked when event handler is triggered
+   */
   on(
     type: `${REALTIME_LISTEN_TYPES.BROADCAST}`,
     filter: { event: string },

--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -159,10 +159,17 @@ export default class RealtimeClient {
     }
   }
 
+  /**
+   * Returns all created channels
+   */
   getChannels(): RealtimeChannel[] {
     return this.channels
   }
 
+  /**
+   * Unsubscribes and removes a single channel
+   * @param channel A RealtimeChannel instance
+   */
   removeChannel(
     channel: RealtimeChannel
   ): Promise<RealtimeRemoveChannelResponse> {
@@ -174,6 +181,9 @@ export default class RealtimeClient {
     })
   }
 
+  /**
+   * Unsubscribes and removes all channels
+   */
   removeAllChannels(): Promise<RealtimeRemoveChannelResponse[]> {
     return Promise.all(
       this.channels.map((channel) => channel.unsubscribe())


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the new behavior?

Add jsdoc for `RealtimeChannel.on`, `RealtimeClient.getChannels`, `RealtimeClient.removeChannel`, `RealtimeClient.removeAllChannels`.
