### PR TITLE
fix: adding initial typescript support on presence

### DIFF
--- a/src/RealtimeChannel.ts
+++ b/src/RealtimeChannel.ts
@@ -338,15 +338,15 @@ export default class RealtimeChannel {
     filter: { event: `${REALTIME_PRESENCE_LISTEN_EVENTS.SYNC}` },
     callback: () => void
   ): RealtimeChannel
-  on(
+  on<T>(
     type: `${REALTIME_LISTEN_TYPES.PRESENCE}`,
     filter: { event: `${REALTIME_PRESENCE_LISTEN_EVENTS.JOIN}` },
-    callback: (payload: RealtimePresenceJoinPayload) => void
+    callback: (payload: RealtimePresenceJoinPayload<T>) => void
   ): RealtimeChannel
-  on(
+  on<T>(
     type: `${REALTIME_LISTEN_TYPES.PRESENCE}`,
     filter: { event: `${REALTIME_PRESENCE_LISTEN_EVENTS.LEAVE}` },
-    callback: (payload: RealtimePresenceLeavePayload) => void
+    callback: (payload: RealtimePresenceLeavePayload<T>) => void
   ): RealtimeChannel
   on<T extends { [key: string]: any }>(
     type: `${REALTIME_LISTEN_TYPES.POSTGRES_CHANGES}`,

--- a/src/RealtimePresence.ts
+++ b/src/RealtimePresence.ts
@@ -17,18 +17,20 @@ type Presence = {
 
 export type RealtimePresenceState = { [key: string]: Presence[] }
 
-export type RealtimePresenceJoinPayload = {
+export type RealTimeGenericPresence<T> = Presence & T
+
+export type RealtimePresenceJoinPayload<T> = {
   event: `${REALTIME_PRESENCE_LISTEN_EVENTS.JOIN}`
   key: string
-  currentPresences: Presence[]
-  newPresences: Presence[]
+  currentPresences: RealTimeGenericPresence<T>[]
+  newPresences: RealTimeGenericPresence<T>[]
 }
 
-export type RealtimePresenceLeavePayload = {
+export type RealtimePresenceLeavePayload<T> = {
   event: `${REALTIME_PRESENCE_LISTEN_EVENTS.LEAVE}`
   key: string
-  currentPresences: Presence[]
-  leftPresences: Presence[]
+  currentPresences: RealTimeGenericPresence<T>[]
+  leftPresences: RealTimeGenericPresence<T>[]
 }
 
 export enum REALTIME_PRESENCE_LISTEN_EVENTS {


### PR DESCRIPTION
## What kind of change does this PR introduce?
TS support

## What is the current behavior?
```ts
interface UserType {
  id: number
  name: string
}

const user: UserType = {
  id: 1,
  name: 'John Doe',
}

const channel = client.channel('test-channel')

channel.subscribe(async (status) => {
  if (status === 'SUBSCRIBED') {
    await channel.track(user)
  }
})

channel.on('presence', { event: 'join' }, ({ newPresences }) => {
  for (const presence of newPresences) {
    console.log({
      id: presence.id, // property id is not part of Presence and it's never infered
      name: presence.name, // property name is not part of Presence and it's never infered
      presence_ref: user.presence_ref,
    })
  }
})
```

## What is the new behavior?
```ts
interface UserType {
  id: number
  name: string
}

const user: UserType = {
  id: 1,
  name: 'John Doe',
}

const channel = client.channel('test-channel')

channel.subscribe(async (status) => {
  if (status === 'SUBSCRIBED') {
    await channel.track(user)
  }
})

channel.on<UserType>('presence', { event: 'join' }, ({ newPresences }) => {
  for (const presence of newPresences) {
    console.log({
      id: presence.id,
      name: presence.name,
      presence_ref: presence.presence_ref,
    })
  }
})
```

![image](https://user-images.githubusercontent.com/17607894/210903300-7b70f72d-ddac-4166-8126-582b13a0471b.png)

## Additional context

Add any other context or screenshots.
