### PR TITLE
feat: disable throttle with negative eventsPerSecond number

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ channel.subscribe((status, err) => {
 - `REALTIME_URL` is `'ws://localhost:4000/socket'` when developing locally and `'wss://<project_ref>.supabase.co/realtime/v1'` when connecting to your Supabase project.
 - `API_KEY` is a JWT whose claims must contain `exp` and `role` (existing database role).
 - Channel name can be any `string`.
-- `eventsPerSecond`, or client-side rate limiting, enforces the number of events sent to the Realtime server uniformly spread across a second. The default is 10, which means that the client can send one event, whether that's **Broadcast**/**Presence**/**Postgres CDC**, every 100 milliseconds. You may change this as you see fit but note that the server's rate limiting will need to be updated accordingly. You can learn more about Realtime's rate limits here: https://supabase.com/docs/guides/realtime/rate-limits.
+- `eventsPerSecond`, or client-side rate limiting, enforces the number of events sent to the Realtime server uniformly spread across a second. The default is 10, which means that the client can send one event, whether that's **Broadcast**/**Presence**/**Postgres CDC**, every 100 milliseconds. You may change this as you see fit, and choose to disable by passing in a negative number, but note that the server's rate limiting will need to be updated accordingly. You can learn more about Realtime's rate limits here: https://supabase.com/docs/guides/realtime/rate-limits.
 
 ## Broadcast
 

--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -450,15 +450,21 @@ export default class RealtimeClient {
   /** @internal */
   private _throttle(
     callback: Function,
-    eventsPerSecondLimit: number = this.eventsPerSecondLimitMs
+    eventsPerSecondLimitMs: number = this.eventsPerSecondLimitMs
   ): () => boolean {
     return () => {
       if (this.inThrottle) return true
+
       callback()
-      this.inThrottle = true
-      setTimeout(() => {
-        this.inThrottle = false
-      }, eventsPerSecondLimit)
+
+      if (eventsPerSecondLimitMs > 0) {
+        this.inThrottle = true
+
+        setTimeout(() => {
+          this.inThrottle = false
+        }, eventsPerSecondLimitMs)
+      }
+
       return false
     }
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Enable disabling of the throttle, default is 10, by passing in a negative number for `eventsPerSecond`.

## Additional context

Addresses: https://github.com/supabase/realtime-js/issues/220
