### PR TITLE
Allow consumers to pass presence state types to channel.presenceState

### DIFF
--- a/src/RealtimeChannel.ts
+++ b/src/RealtimeChannel.ts
@@ -57,22 +57,24 @@ export type RealtimePostgresChangesPayload<T extends { [key: string]: any }> =
   | RealtimePostgresUpdatePayload<T>
   | RealtimePostgresDeletePayload<T>
 
-export type RealtimePostgresChangesFilter<T extends `${REALTIME_POSTGRES_CHANGES_LISTEN_EVENT}`> = {
+export type RealtimePostgresChangesFilter<
+  T extends `${REALTIME_POSTGRES_CHANGES_LISTEN_EVENT}`
+> = {
   /**
-  * The type of database change to listen to.
-  */
+   * The type of database change to listen to.
+   */
   event: T
   /**
-  * The database schema to listen to.
-  */
+   * The database schema to listen to.
+   */
   schema: string
   /**
-  * The database table to listen to.
-  */
+   * The database table to listen to.
+   */
   table?: string
   /**
-  * Receive database changes when filter is matched.
-  */
+   * Receive database changes when filter is matched.
+   */
   filter?: string
 }
 
@@ -296,8 +298,10 @@ export default class RealtimeChannel {
     return this
   }
 
-  presenceState(): RealtimePresenceState {
-    return this.presence.state
+  presenceState<
+    T extends { [key: string]: any } = {}
+  >(): RealtimePresenceState<T> {
+    return this.presence.state as RealtimePresenceState<T>
   }
 
   async track(

--- a/src/RealtimePresence.ts
+++ b/src/RealtimePresence.ts
@@ -14,7 +14,9 @@ type Presence<T extends { [key: string]: any } = {}> = {
   presence_ref: string
 } & T
 
-export type RealtimePresenceState = { [key: string]: Presence[] }
+export type RealtimePresenceState<T extends { [key: string]: any } = {}> = {
+  [key: string]: Presence<T>[]
+}
 
 export type RealtimePresenceJoinPayload<T extends { [key: string]: any }> = {
   event: `${REALTIME_PRESENCE_LISTEN_EVENTS.JOIN}`


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update types for `channel.presenceState()` to allow users to pass a type for their state. This will stop users having to cast the state on usuage.

## What is the current behavior?

Not able to pass the presence state type to channel.presenceState()

## What is the new behavior?

N/A

## Additional context

<img width="832" alt="Screenshot 2023-01-30 at 17 03 18" src="https://user-images.githubusercontent.com/1982678/215544533-29ef4d45-5e3d-46e7-8587-54e1f4b41690.png">

Fixes #223 
