### PR TITLE
Fix #229

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
   },
   "dependencies": {
     "@types/phoenix": "^1.5.4",
+    "@types/websocket": "^1.0.3",
     "websocket": "^1.0.34"
   },
   "devDependencies": {
     "@babel/runtime": "^7.9.2",
-    "@types/websocket": "^1.0.3",
     "babel-preset-env": "^1.7.0",
     "babel-register": "^6.26.0",
     "eslint": "^7.0.0",

--- a/src/RealtimeChannel.ts
+++ b/src/RealtimeChannel.ts
@@ -3,10 +3,12 @@ import Push from './lib/push'
 import type RealtimeClient from './RealtimeClient'
 import Timer from './lib/timer'
 import RealtimePresence, {
-  type RealtimePresenceJoinPayload,
-  type RealtimePresenceLeavePayload,
-  type RealtimePresenceState,
   REALTIME_PRESENCE_LISTEN_EVENTS,
+} from './RealtimePresence'
+import type {
+  RealtimePresenceJoinPayload,
+  RealtimePresenceLeavePayload,
+  RealtimePresenceState,
 } from './RealtimePresence'
 import * as Transformers from './lib/transformers'
 

--- a/src/RealtimeChannel.ts
+++ b/src/RealtimeChannel.ts
@@ -1,11 +1,11 @@
 import { CHANNEL_EVENTS, CHANNEL_STATES } from './lib/constants'
 import Push from './lib/push'
-import RealtimeClient from './RealtimeClient'
+import type RealtimeClient from './RealtimeClient'
 import Timer from './lib/timer'
 import RealtimePresence, {
-  RealtimePresenceJoinPayload,
-  RealtimePresenceLeavePayload,
-  RealtimePresenceState,
+  type RealtimePresenceJoinPayload,
+  type RealtimePresenceLeavePayload,
+  type RealtimePresenceState,
   REALTIME_PRESENCE_LISTEN_EVENTS,
 } from './RealtimePresence'
 import * as Transformers from './lib/transformers'

--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -11,7 +11,7 @@ import {
 } from './lib/constants'
 import Timer from './lib/timer'
 import Serializer from './lib/serializer'
-import RealtimeChannel, { RealtimeChannelOptions } from './RealtimeChannel'
+import RealtimeChannel, { type RealtimeChannelOptions } from './RealtimeChannel'
 
 export type RealtimeClientOptions = {
   transport?: WebSocket

--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -170,27 +170,25 @@ export default class RealtimeClient {
    * Unsubscribes and removes a single channel
    * @param channel A RealtimeChannel instance
    */
-  removeChannel(
+  async removeChannel(
     channel: RealtimeChannel
   ): Promise<RealtimeRemoveChannelResponse> {
-    return channel.unsubscribe().then((status) => {
-      if (this.channels.length === 0) {
-        this.disconnect()
-      }
-      return status
-    })
+    const status = await channel.unsubscribe()
+    if (this.channels.length === 0) {
+      this.disconnect()
+    }
+    return status
   }
 
   /**
    * Unsubscribes and removes all channels
    */
-  removeAllChannels(): Promise<RealtimeRemoveChannelResponse[]> {
-    return Promise.all(
+  async removeAllChannels(): Promise<RealtimeRemoveChannelResponse[]> {
+    const values_1 = await Promise.all(
       this.channels.map((channel) => channel.unsubscribe())
-    ).then((values) => {
-      this.disconnect()
-      return values
-    })
+    )
+    this.disconnect()
+    return values_1
   }
 
   /**

--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -11,7 +11,8 @@ import {
 } from './lib/constants'
 import Timer from './lib/timer'
 import Serializer from './lib/serializer'
-import RealtimeChannel, { type RealtimeChannelOptions } from './RealtimeChannel'
+import RealtimeChannel from './RealtimeChannel'
+import type { RealtimeChannelOptions } from './RealtimeChannel'
 
 export type RealtimeClientOptions = {
   transport?: WebSocket

--- a/src/RealtimePresence.ts
+++ b/src/RealtimePresence.ts
@@ -3,12 +3,12 @@
   License: https://github.com/phoenixframework/phoenix/blob/d344ec0a732ab4ee204215b31de69cf4be72e3bf/LICENSE.md
 */
 
-import {
+import type {
   PresenceOpts,
   PresenceOnJoinCallback,
   PresenceOnLeaveCallback,
 } from 'phoenix'
-import RealtimeChannel from './RealtimeChannel'
+import type RealtimeChannel from './RealtimeChannel'
 
 type Presence<T extends { [key: string]: any } = {}> = {
   presence_ref: string

--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_TIMEOUT } from '../lib/constants'
-import RealtimeChannel from '../RealtimeChannel'
+import type RealtimeChannel from '../RealtimeChannel'
 
 export default class Push {
   sent: boolean = false

--- a/src/lib/transformers.ts
+++ b/src/lib/transformers.ts
@@ -106,7 +106,7 @@ export const convertColumn = (
  * If the value of the cell is `null`, returns null.
  * Otherwise converts the string value to the correct type.
  * @param {String} type A postgres column type
- * @param {String} stringValue The cell value
+ * @param {String} value The cell value
  *
  * @example convertCell('bool', 't')
  * //=> true


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

See #229 

## What is the new behavior?

All errors are gone.

Only for this:
```
/Users/********/supabase-realtime-js-typescript-errors/node_modules/@supabase/realtime-js/src/RealtimeClient.ts:1:30
Error: Could not find a declaration file for module 'websocket'. '/Users/********/supabase-realtime-js-typescript-errors/node_modules/websocket/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/websocket` if it exists or add a new declaration (.d.ts) file containing `declare module 'websocket';`
import { w3cwebsocket } from 'websocket'
import {
```

I didn't test. But I think moving `"@types/websocket": "^1.0.3",` from `devDependencies` to `dependencies` should fix it.
