### PR TITLE
fix: set initial access token

### DIFF
--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -104,7 +104,6 @@ export default class RealtimeClient {
 
     const accessToken = options?.params?.apikey
     if (accessToken) this.accessToken = accessToken
-    console.log({ accessToken })
 
     this.reconnectAfterMs = options?.reconnectAfterMs
       ? options.reconnectAfterMs

--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -23,7 +23,7 @@ export type RealtimeClientOptions = {
   decode?: Function
   reconnectAfterMs?: Function
   headers?: { [key: string]: string }
-  params?: { [key: string]: any },
+  params?: { [key: string]: any }
   log_level?: 'info' | 'debug' | 'warn' | 'error'
 }
 
@@ -104,6 +104,7 @@ export default class RealtimeClient {
 
     const accessToken = options?.params?.apikey
     if (accessToken) this.accessToken = accessToken
+    console.log({ accessToken })
 
     this.reconnectAfterMs = options?.reconnectAfterMs
       ? options.reconnectAfterMs

--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -103,7 +103,7 @@ export default class RealtimeClient {
       this.eventsPerSecondLimitMs = Math.floor(1000 / eventsPerSecond)
 
     const accessToken = options?.params?.apikey
-    if(accessToken) this.accessToken = accessToken
+    if (accessToken) this.accessToken = accessToken
 
     this.reconnectAfterMs = options?.reconnectAfterMs
       ? options.reconnectAfterMs

--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -102,6 +102,9 @@ export default class RealtimeClient {
     if (eventsPerSecond)
       this.eventsPerSecondLimitMs = Math.floor(1000 / eventsPerSecond)
 
+    const accessToken = options?.params?.apikey
+    if(accessToken) this.accessToken = accessToken
+
     this.reconnectAfterMs = options?.reconnectAfterMs
       ? options.reconnectAfterMs
       : (tries: number) => {

--- a/test/channel_test.js
+++ b/test/channel_test.js
@@ -1202,4 +1202,12 @@ describe('trigger', () => {
       )
     )
   })
+
+  it('sets apikey as initial accessToken', () => {
+    socket = new RealtimeClient('ws://example.com/socket', {
+      timeout: defaultTimeout,
+      apikey: '123',
+    })
+    assert.equal(socket.accessToken, '123')
+  })
 })

--- a/test/channel_test.js
+++ b/test/channel_test.js
@@ -1204,10 +1204,10 @@ describe('trigger', () => {
   })
 
   it('sets apikey as initial accessToken', () => {
-    socket = new RealtimeClient('ws://example.com/socket', {
+    const client = new RealtimeClient('ws://example.com/socket', {
       timeout: defaultTimeout,
-      apikey: '123',
+      params: {apikey: '123'}
     })
-    assert.equal(socket.accessToken, '123')
+    assert.equal(client.accessToken, '123')
   })
 })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes the issue where using Supabase realtime without signing in sends `null` access token to the server. 

Currently, `accessToken` of `RealtimeClient` class is only set within `setAuth`, but if the user is not signed in via Supabase Auth, `realtime.setAuth` is never called, hence resulting in `null` `accessToken` value. 

This PR updates `RealtimeClient` to use the `apikey`, which contains either the anonkey or the service role key as the initial value of `accessToken`. 