### PR TITLE
feat: send messages via broadcast endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0-automated",
       "license": "MIT",
       "dependencies": {
+        "@supabase/node-fetch": "^2.6.14",
         "@types/phoenix": "^1.5.4",
         "@types/websocket": "^1.0.3",
         "websocket": "^1.0.34"
@@ -859,6 +860,36 @@
       "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
+    },
+    "node_modules/@supabase/node-fetch": {
+      "version": "2.6.14",
+      "resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.14.tgz",
+      "integrity": "sha512-w/Tsd22e/5fAeoxqQ4P2MX6EyF+iM6rc9kmlMVFkHuG0rAltt2TLhFbDJfemnHbtvnazWaRfy5KnFU/SYT37dQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
+    "node_modules/@supabase/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/@supabase/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/@supabase/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "docs:json": "typedoc --json docs/v2/spec.json --excludeExternals src/index.ts"
   },
   "dependencies": {
+    "@supabase/node-fetch": "^2.6.14",
     "@types/phoenix": "^1.5.4",
     "@types/websocket": "^1.0.3",
     "websocket": "^1.0.34"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "outDir": "dist/main",
     "rootDir": "src",
     "sourceMap": true,
-    "target": "ES2015",
+    "target": "ES2017",
 
     "strict": true,
 

--- a/tsconfig.module.json
+++ b/tsconfig.module.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "module": "ES2015",
+    "module": "ES2020",
     "outDir": "dist/module"
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the new behavior?

Enables sending messages to server via a broadcast HTTP endpoint request instead of waiting for a WebSocket connection, subscribing to a channel, and then sending messages.

## Usage example

```js
import { RealtimeClient } from '@supabase/realtime-js'

const client = new RealtimeClient(REALTIME_URL, {
  params: {
    apikey: API_KEY
  },
})

const channel = client.channel('test-channel')

// No need to subscribe to channel

channel.send({
  type: 'broadcast',
  event: 'test',
  payload: { message: "Hi" }
).then(resp => { console.log(resp) })

// Remember to clean up the channel

client.removeChannel(channel)
```
