### PR TITLE
fix: remove rate limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ import { RealtimeClient } from '@supabase/realtime-js'
 
 const client = new RealtimeClient(REALTIME_URL, {
   params: {
-    apikey: API_KEY,
-    eventsPerSecond: 10,
+    apikey: API_KEY
   },
 })
 
@@ -75,7 +74,6 @@ channel.subscribe((status, err) => {
 - `REALTIME_URL` is `'ws://localhost:4000/socket'` when developing locally and `'wss://<project_ref>.supabase.co/realtime/v1'` when connecting to your Supabase project.
 - `API_KEY` is a JWT whose claims must contain `exp` and `role` (existing database role).
 - Channel name can be any `string`.
-- `eventsPerSecond`, or client-side rate limiting, enforces the number of events sent to the Realtime server uniformly spread across a second. The default is 10, which means that the client can send one event, whether that's **Broadcast**/**Presence**/**Postgres CDC**, every 100 milliseconds. You may change this as you see fit, and choose to disable by passing in a negative number, but note that the server's rate limiting will need to be updated accordingly. You can learn more about Realtime's rate limits here: https://supabase.com/docs/guides/realtime/rate-limits.
 
 ## Broadcast
 

--- a/src/RealtimeChannel.ts
+++ b/src/RealtimeChannel.ts
@@ -80,11 +80,7 @@ export type RealtimePostgresChangesFilter<
   filter?: string
 }
 
-export type RealtimeChannelSendResponse =
-  | 'ok'
-  | 'timed out'
-  | 'rate limited'
-  | 'error'
+export type RealtimeChannelSendResponse = 'ok' | 'timed out' | 'error'
 
 export enum REALTIME_POSTGRES_CHANGES_LISTEN_EVENT {
   ALL = '*',
@@ -461,10 +457,6 @@ export default class RealtimeChannel {
     } else {
       return new Promise((resolve) => {
         const push = this._push(args.type, args, opts.timeout || this.timeout)
-
-        if (push.rateLimited) {
-          resolve('rate limited')
-        }
 
         if (args.type === 'broadcast' && !this.params?.config?.broadcast?.ack) {
           resolve('ok')

--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -14,7 +14,6 @@ export default class Push {
     callback: Function
   }[] = []
   refEvent: string | null = null
-  rateLimited: boolean = false
 
   /**
    * Initializes the Push
@@ -47,16 +46,13 @@ export default class Push {
     }
     this.startTimeout()
     this.sent = true
-    const status = this.channel.socket.push({
+    this.channel.socket.push({
       topic: this.channel.topic,
       event: this.event,
       payload: this.payload,
       ref: this.ref,
       join_ref: this.channel._joinRef(),
     })
-    if (status === 'rate limited') {
-      this.rateLimited = true
-    }
   }
 
   updatePayload(payload: { [key: string]: any }): void {

--- a/test/channel_test.js
+++ b/test/channel_test.js
@@ -1088,7 +1088,7 @@ describe('send', () => {
       if (status === "SUBSCRIBED") {
         pushStub = sinon.stub(channel, '_push')
         pushStub.returns({
-          rateLimited: false, receive: (status, cb) => {
+          receive: (status, cb) => {
             if (status === 'ok') cb()
           }
         })
@@ -1100,24 +1100,11 @@ describe('send', () => {
     })
   })
 
-  it("tries to send message via ws conn when subscribed to channel but is rate limited", async () => {
-    channel.subscribe(async status => {
-      if (status === "SUBSCRIBED") {
-        pushStub = sinon.stub(channel, '_push')
-        pushStub.returns({ rateLimited: true })
-
-        const res = await channel.send({ type: 'test', id: 'u123' })
-
-        assert.equal(res, 'rate limited')
-      }
-    })
-  })
-
   it("tries to send message via ws conn when subscribed to channel but times out", async () => {
     channel.subscribe(async status => {
       if (status === "SUBSCRIBED") {
         pushStub = sinon.stub(channel, '_push')
-        pushStub.returns({ rateLimited: false, receive: (status, cb) => {
+        pushStub.returns({ receive: (status, cb) => {
           if (status === 'timeout') cb()
         }})
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix

## What is the current behavior?

There's a rate limiter in place that allows one event every 100 milliseconds but this can be customized.

## What is the new behavior?

There is no rate limiter.
