### PR TITLE
fix: Add missing `on` overload for Broadcasts

### DIFF
--- a/src/RealtimeChannel.ts
+++ b/src/RealtimeChannel.ts
@@ -395,6 +395,15 @@ export default class RealtimeChannel {
       [key: string]: any
     }) => void
   ): RealtimeChannel
+  on<T extends { [key: string]: any }>(
+    type: `${REALTIME_LISTEN_TYPES.BROADCAST}`,
+    filter: { event: string },
+    callback: (payload: {
+      type: `${REALTIME_LISTEN_TYPES.BROADCAST}`
+      event: string
+      [key: string]: any
+    }) => void
+  ): RealtimeChannel
   on(
     type: `${REALTIME_LISTEN_TYPES}`,
     filter: { event: string; [key: string]: string },

--- a/src/RealtimeChannel.ts
+++ b/src/RealtimeChannel.ts
@@ -401,7 +401,7 @@ export default class RealtimeChannel {
     callback: (payload: {
       type: `${REALTIME_LISTEN_TYPES.BROADCAST}`
       event: string
-      [key: string]: any
+      payload: T
     }) => void
   ): RealtimeChannel
   on(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add missing `on` overload for Broadcasts

## Additional context
Example code was causing issues to user in https://github.com/supabase/realtime-js/issues/259 

<img width="1142" alt="Screenshot 2023-10-25 at 01 03 49" src="https://github.com/supabase/realtime-js/assets/1697301/dee10baa-d715-46cd-ae68-4230dff7319f">
