### PR TITLE
fix: channel.send() via REST api

### DIFF
--- a/src/RealtimeChannel.ts
+++ b/src/RealtimeChannel.ts
@@ -436,7 +436,7 @@ export default class RealtimeChannel {
       const options = {
         method: 'POST',
         headers: {
-          apikey: this.socket.accessToken ?? '',
+          apikey: this.socket.apiKey ?? '',
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({

--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -63,6 +63,7 @@ const NATIVE_WEBSOCKET_AVAILABLE = typeof WebSocket !== 'undefined'
 
 export default class RealtimeClient {
   accessToken: string | null = null
+  apiKey: string | null = null
   channels: RealtimeChannel[] = []
   endPoint: string = ''
   headers?: { [key: string]: string } = DEFAULT_HEADERS
@@ -124,7 +125,10 @@ export default class RealtimeClient {
       this.heartbeatIntervalMs = options.heartbeatIntervalMs
 
     const accessToken = options?.params?.apikey
-    if (accessToken) this.accessToken = accessToken
+    if (accessToken) {
+      this.accessToken = accessToken
+      this.apiKey = accessToken
+    }
 
     this.reconnectAfterMs = options?.reconnectAfterMs
       ? options.reconnectAfterMs


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?
Instead of using `anon key` it uses user `accessToken`

https://github.com/supabase/realtime-js/issues/271

## What is the new behavior?

Channel.send() via REST api works as expected

