### PR TITLE
chore: sets up next branch as npm prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - next
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore

## What is the new behavior?

Pushing to `next` branch will generate npm next prereleases

## Additional context

https://github.com/supabase/supabase-js/pull/454#issue-1262744424
