### PR TITLE
fix: accept error message from server when tracking Presence

### DIFF
--- a/src/RealtimeChannel.ts
+++ b/src/RealtimeChannel.ts
@@ -474,6 +474,7 @@ export default class RealtimeChannel {
         }
 
         push.receive('ok', () => resolve('ok'))
+        push.receive('error', () => resolve('error'))
         push.receive('timeout', () => resolve('timed out'))
       })
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Realtime server can send `error` on Presence tracking and client does not accept it.

## What is the new behavior?

Realtime server can send `error` on Presence tracking and client accepts it and resolves; provides proper feedback to clients.

## Additional context

Related: https://github.com/supabase/realtime/pull/844
