### PR TITLE
fix: Broadcast endpoint includes private param in request body

### DIFF
--- a/src/RealtimeChannel.ts
+++ b/src/RealtimeChannel.ts
@@ -135,6 +135,7 @@ export default class RealtimeChannel {
   presence: RealtimePresence
   broadcastEndpointURL: string
   subTopic: string
+  private: boolean
 
   constructor(
     /** Topic name can be any string. */
@@ -198,6 +199,7 @@ export default class RealtimeChannel {
 
     this.broadcastEndpointURL =
       httpEndpointURL(this.socket.endPoint) + '/api/broadcast'
+    this.private = this.params.config.private || false
   }
 
   /** Subscribe registers your client with the server */
@@ -451,7 +453,12 @@ export default class RealtimeChannel {
         },
         body: JSON.stringify({
           messages: [
-            { topic: this.subTopic, event, payload: endpoint_payload },
+            {
+              topic: this.subTopic,
+              event,
+              payload: endpoint_payload,
+              private: this.private,
+            },
           ],
         }),
       }

--- a/src/RealtimeChannel.ts
+++ b/src/RealtimeChannel.ts
@@ -199,7 +199,7 @@ export default class RealtimeChannel {
 
     this.broadcastEndpointURL =
       httpEndpointURL(this.socket.endPoint) + '/api/broadcast'
-    this.private = this.params.config.private !== false
+    this.private = this.params.config.private || false
   }
 
   /** Subscribe registers your client with the server */

--- a/src/RealtimeChannel.ts
+++ b/src/RealtimeChannel.ts
@@ -199,7 +199,7 @@ export default class RealtimeChannel {
 
     this.broadcastEndpointURL =
       httpEndpointURL(this.socket.endPoint) + '/api/broadcast'
-    this.private = this.params.config.private || false
+    this.private = this.params.config.private !== false
   }
 
   /** Subscribe registers your client with the server */

--- a/test/channel_test.js
+++ b/test/channel_test.js
@@ -24,7 +24,11 @@ describe('constructor', () => {
     assert.equal(channel.state, 'closed')
     assert.equal(channel.topic, 'topic')
     assert.deepEqual(channel.params, {
-      config: { broadcast: { ack: false, self: false }, presence: { key: '' }, private: false },
+      config: {
+        broadcast: { ack: false, self: false },
+        presence: { key: '' },
+        private: false,
+      },
       one: 'two',
     })
     assert.deepEqual(channel.socket, socket)
@@ -40,7 +44,11 @@ describe('constructor', () => {
 
     assert.deepEqual(joinPush.channel, channel)
     assert.deepEqual(joinPush.payload, {
-      config: { broadcast: { ack: false, self: false }, presence: { key: '' }, private: false },
+      config: {
+        broadcast: { ack: false, self: false },
+        presence: { key: '' },
+        private: false,
+      },
       one: 'two',
     })
     assert.equal(joinPush.event, 'phx_join')
@@ -1232,7 +1240,7 @@ describe('send', () => {
     socket = new RealtimeClient('ws://localhost:4000/socket', {
       params: { apikey: 'abc123' },
     })
-    channel = socket.channel('topic', { one: 'two' })
+    channel = socket.channel('topic', { one: 'two', config: { private: true } })
   })
 
   afterEach(() => {
@@ -1275,6 +1283,16 @@ describe('send', () => {
   })
 
   it('sends message via http request to Broadcast endpoint when not subscribed to channel', async () => {
+    const expectedBody = {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer abc123',
+        apikey: 'abc123',
+        'Content-Type': 'application/json',
+      },
+      body: '{"messages":[{"topic":"topic","event":"test","private":true}]}',
+    }
+
     pushStub = sinon.stub(channel, '_fetchWithTimeout')
     pushStub.returns(new Response())
 
@@ -1285,7 +1303,12 @@ describe('send', () => {
     })
 
     assert.equal(res, 'ok')
-    assert.ok(pushStub.calledOnceWith('http://localhost:4000/api/broadcast'))
+    assert.ok(
+      pushStub.calledOnceWith(
+        'http://localhost:4000/api/broadcast',
+        expectedBody
+      )
+    )
   })
 })
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Broadcast endpoint includes private param in request body