### PR TITLE
fix: Remove ws library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,11 @@
       "version": "0.0.0-automated",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14",
-        "@types/phoenix": "^1.5.4",
-        "@types/ws": "^8.5.10",
-        "ws": "^8.14.2"
+        "@supabase/node-fetch": "^2.6.14"
       },
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.16.2",
+        "@types/phoenix": "^1.5.4",
         "@types/sinon": "^17.0.3",
         "@vitest/coverage-v8": "^2.0.5",
         "eslint": "^7.0.0",
@@ -1518,7 +1516,10 @@
       "version": "22.3.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.3.0.tgz",
       "integrity": "sha512-nrWpWVaDZuaVc5X84xJ0vNrLvomM205oQyLsRt7OHNZbSHslcWsvgFR7O7hire2ZonjLrWBbedmotmIlJDVd6g==",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.18.2"
       }
@@ -1527,6 +1528,7 @@
       "version": "1.6.5",
       "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.5.tgz",
       "integrity": "sha512-xegpDuR+z0UqG9fwHqNoy3rI7JDlvaPh2TY47Fl80oq6g+hXT+c/LEuE43X48clZ6lOfANl5WrPur9fYO1RJ/w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/sinon": {
@@ -1545,15 +1547,6 @@
       "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/ws": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.12.tgz",
-      "integrity": "sha512-3tPRkv1EtkDpzlgyKyI8pGsGZAGPEaXeu0DOj5DI25Ja91bdAYddYHbADRYVrZMRbfW+1l5YwXVDKohDJNQxkQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@vitest/coverage-v8": {
       "version": "2.0.5",
@@ -6971,7 +6964,10 @@
       "version": "6.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.18.2.tgz",
       "integrity": "sha512-5ruQbENj95yDYJNS3TvcaxPMshV7aizdv/hWYjGIKoANWKjhWNBsr2YEuYZKodQulB1b8l7ILOuDQep3afowQQ==",
-      "license": "MIT"
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/unicode-emoji-modifier-base": {
       "version": "1.0.0",
@@ -7451,27 +7447,6 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -38,14 +38,12 @@
     "ci": "run-s test coverage"
   },
   "dependencies": {
-    "@supabase/node-fetch": "^2.6.14",
-    "@types/phoenix": "^1.5.4",
-    "@types/ws": "^8.5.10",
-    "ws": "^8.14.2"
+    "@supabase/node-fetch": "^2.6.14"
   },
   "devDependencies": {
-    "@arethetypeswrong/cli": "^0.16.2",
     "@types/sinon": "^17.0.3",
+    "@types/phoenix": "^1.5.4",
+    "@arethetypeswrong/cli": "^0.16.2",
     "@vitest/coverage-v8": "^2.0.5",
     "eslint": "^7.0.0",
     "esm": "^3.2.25",

--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -1,5 +1,3 @@
-import type { WebSocket as WSWebSocket } from 'ws'
-
 import {
   CHANNEL_EVENTS,
   CONNECTION_STATE,
@@ -60,7 +58,7 @@ interface WebSocketLikeConstructor {
   ): WebSocketLike
 }
 
-type WebSocketLike = WebSocket | WSWebSocket | WSWebSocketDummy
+type WebSocketLike = WebSocket | WSWebSocketDummy
 
 interface WebSocketLikeError {
   error: any
@@ -89,7 +87,7 @@ export default class RealtimeClient {
   encode: Function
   decode: Function
   reconnectAfterMs: Function
-  conn: WebSocketLike | null = null
+  conn: any | null = null
   sendBuffer: Function[] = []
   serializer: Serializer = new Serializer()
   stateChangeCallbacks: {
@@ -186,13 +184,6 @@ export default class RealtimeClient {
       close: () => {
         this.conn = null
       },
-    })
-
-    import('ws').then(({ default: WS }) => {
-      this.conn = new WS(this._endPointURL(), undefined, {
-        headers: this.headers,
-      })
-      this.setupConnection()
     })
   }
 

--- a/test/socket.test.ts
+++ b/test/socket.test.ts
@@ -1,7 +1,6 @@
 import assert from 'assert'
 import { describe, beforeEach, afterEach, test } from 'vitest'
 import { Server as MockServer, WebSocket as MockWebSocket } from 'mock-socket'
-import WebSocket from 'ws'
 import sinon from 'sinon'
 
 import RealtimeClient from '../src/RealtimeClient'


### PR DESCRIPTION
## What kind of change does this PR introduce?

With the added support to native web sockets we no longer need ws as an imports.

