### PR TITLE
Add setupConnection call to custom transports

### DIFF
--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -193,6 +193,7 @@ export default class RealtimeClient {
       this.conn = new this.transport(this._endPointURL(), undefined, {
         headers: this.headers,
       })
+      this.setupConnection()
       return
     }
     if (NATIVE_WEBSOCKET_AVAILABLE) {


### PR DESCRIPTION
Enabling proper implementation of custom transports

## What kind of change does this PR introduce?

Enables custom transports to be implemented properly - currently missing `this.setupConnection()` call after initialisation, which makes the use of custom transports impossible.

## What is the current behavior?

Can't use custom transports without rewriting the whole RealtimeClient

## What is the new behavior?

Sets up custom transports with listeners properly

## Additional context

Fixes #433 

We have tested it locally, and our custom transport (running in a SharedWorker) works properly now.
