### PR TITLE
fix: Access token callback can be null

### DIFF
--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -112,7 +112,7 @@ export default class RealtimeClient {
     message: [],
   }
   fetch: Fetch
-  accessToken: (() => Promise<string>) | null = null
+  accessToken: (() => Promise<string | null>) | null = null
   worker?: boolean
   workerUrl?: string
   workerRef?: Worker

--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -1203,7 +1203,6 @@ describe('send', () => {
     const pushStub = sinon.stub(new_channel, '_push')
 
     new_channel.subscribe(async (status) => {
-      console.log(status)
       if (status === 'SUBSCRIBED') {
         subscribed = true
         await new_channel.send({ type: 'broadcast', event: 'test' })
@@ -1232,7 +1231,6 @@ describe('send', () => {
     const pushStub = sinon.stub(new_channel, '_push')
 
     new_channel.subscribe(async (status) => {
-      console.log(status)
       if (status === 'TIMED_OUT') {
         timed_out = true
       }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Access token callback can be null