### PR TITLE
fix: set log level on params

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -44,3 +44,9 @@ export enum CONNECTION_STATE {
   Closing = 'closing',
   Closed = 'closed',
 }
+
+export enum LOG_LEVEL {
+  Info = 'info',
+  Warn = 'warn',
+  Error = 'error',
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

* Deprecation of log_level to logLevel
* Exports type of log level supported
* Fixes log level being sent in URL params
* Changes heartbeat to default to 25s
