### PR TITLE
chore: downgrade typedoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "prettier": "^2.1.2",
     "semantic-release-plugin-update-version-in-files": "^1.1.0",
     "sinon": "^18.0.0",
-    "typedoc": "^0.27.6",
+    "typedoc": "0.22.16",
     "typescript": "^5.7.3",
     "vitest": "^2.1.9",
     "web-worker": "1.2.0"


### PR DESCRIPTION
Docs uses the typespec and is only compatible with 0.22.16. The new one has breaking changes.

WIP: current version of TS not supported, trying to find workaround...