### PR TITLE
feat(realtime): enhance RealtimeChannel type

### DIFF
--- a/src/RealtimeChannel.ts
+++ b/src/RealtimeChannel.ts
@@ -31,6 +31,38 @@ export type RealtimeChannelOptions = {
   }
 }
 
+type RealtimeBroadcastChangesPayloadBase = {
+  id: string
+  schema: string
+  table: string
+}
+
+export type RealtimeBroadcastInsertPayload<T extends { [key: string]: any }> =
+  RealtimeBroadcastChangesPayloadBase & {
+    operation: `${REALTIME_POSTGRES_CHANGES_LISTEN_EVENT.INSERT}`
+    record: T
+    old_record: null
+  }
+
+export type RealtimeBroadcastUpdatePayload<T extends { [key: string]: any }> =
+  RealtimeBroadcastChangesPayloadBase & {
+    operation: `${REALTIME_POSTGRES_CHANGES_LISTEN_EVENT.UPDATE}`
+    record: T
+    old_record: T
+  }
+
+export type RealtimeBroadcastDeletePayload<T extends { [key: string]: any }> =
+  RealtimeBroadcastChangesPayloadBase & {
+    operation: `${REALTIME_POSTGRES_CHANGES_LISTEN_EVENT.DELETE}`
+    record: null
+    old_record: T
+  }
+
+export type RealtimeBroadcastPayload<T extends { [key: string]: any }> =
+  | RealtimeBroadcastInsertPayload<T>
+  | RealtimeBroadcastUpdatePayload<T>
+  | RealtimeBroadcastDeletePayload<T>
+
 type RealtimePostgresChangesPayloadBase = {
   schema: string
   table: string
@@ -404,6 +436,42 @@ export default class RealtimeChannel {
       type: `${REALTIME_LISTEN_TYPES.BROADCAST}`
       event: string
       payload: T
+    }) => void
+  ): RealtimeChannel
+  on<T extends { [key: string]: any }>(
+    type: `${REALTIME_LISTEN_TYPES.BROADCAST}`,
+    filter: { event: REALTIME_POSTGRES_CHANGES_LISTEN_EVENT.ALL },
+    callback: (payload: {
+      type: `${REALTIME_LISTEN_TYPES.BROADCAST}`
+      event: REALTIME_POSTGRES_CHANGES_LISTEN_EVENT.ALL
+      payload: RealtimeBroadcastPayload<T>
+    }) => void
+  ): RealtimeChannel
+  on<T extends { [key: string]: any }>(
+    type: `${REALTIME_LISTEN_TYPES.BROADCAST}`,
+    filter: { event: REALTIME_POSTGRES_CHANGES_LISTEN_EVENT.INSERT },
+    callback: (payload: {
+      type: `${REALTIME_LISTEN_TYPES.BROADCAST}`
+      event: REALTIME_POSTGRES_CHANGES_LISTEN_EVENT.INSERT
+      payload: RealtimeBroadcastInsertPayload<T>
+    }) => void
+  ): RealtimeChannel
+  on<T extends { [key: string]: any }>(
+    type: `${REALTIME_LISTEN_TYPES.BROADCAST}`,
+    filter: { event: REALTIME_POSTGRES_CHANGES_LISTEN_EVENT.UPDATE },
+    callback: (payload: {
+      type: `${REALTIME_LISTEN_TYPES.BROADCAST}`
+      event: REALTIME_POSTGRES_CHANGES_LISTEN_EVENT.UPDATE
+      payload: RealtimeBroadcastUpdatePayload<T>
+    }) => void
+  ): RealtimeChannel
+  on<T extends { [key: string]: any }>(
+    type: `${REALTIME_LISTEN_TYPES.BROADCAST}`,
+    filter: { event: REALTIME_POSTGRES_CHANGES_LISTEN_EVENT.DELETE },
+    callback: (payload: {
+      type: `${REALTIME_LISTEN_TYPES.BROADCAST}`
+      event: REALTIME_POSTGRES_CHANGES_LISTEN_EVENT.DELETE
+      payload: RealtimeBroadcastDeletePayload<T>
     }) => void
   ): RealtimeChannel
   on<T extends { [key: string]: any }>(


### PR DESCRIPTION
## What kind of change does this PR introduce?

infer payload types sent by `realtime.broadcast_changes`

## What is the current behavior?

```typescript
  on<{ record: Tables<"todos"> }>("broadcast", { event: "INSERT" }, ({ payload: { record } }) => {})
```

## What is the new behavior?

```typescript
  on<Tables<"todos">>("broadcast", { event: "INSERT" }, ({ payload: { record } }) => {})
```

Feel free to include screenshots if it includes visual changes.

## Additional context

- https://supabase.com/docs/guides/realtime/subscribing-to-database-changes#using-broadcast
- https://github.com/supabase/realtime/blob/23a42553d43d5b4263b1436ab9850d7dea6b7602/lib/realtime/tenants/repo/migrations/20240919163303_add_payload_to_messages.ex#L29-L52
