### PR TITLE
FIX TypeError: Cannot convert undefined or null to object at Object.k…

### DIFF
--- a/src/lib/transformers.ts
+++ b/src/lib/transformers.ts
@@ -65,6 +65,11 @@ export const convertChangeData = (
 ): Record => {
   const skipTypes = options.skipTypes ?? []
 
+  // TypeError: Cannot convert undefined or null to object at Object.keys (<anonymous>) at convertChangeData
+  if (!record) {
+    return {} as Record
+  }
+
   return Object.keys(record).reduce((acc, rec_key) => {
     acc[rec_key] = convertColumn(rec_key, columns, record, skipTypes)
     return acc


### PR DESCRIPTION
# Pull Request: Fix `convertChangeData` type error when handling `DELETE` events

## Overview
This pull request fixes an issue where a `TypeError: Cannot convert undefined or null to object` is thrown when processing `DELETE` events in a Postgres table subscription using `@supabase/realtime-js`.

The problem occurs inside the `convertChangeData` function when the `record` parameter is `null` or `undefined` — which happens naturally for `DELETE` events (since the row no longer exists).

---

## Problem
When a `DELETE` event is triggered on the `transaction.groups` table, the Realtime subscription receives a payload where the `record` is `null`.  
However, the current implementation of `convertChangeData` attempts to call `Object.keys(record)`, which leads to this runtime error:

```
TypeError: Cannot convert undefined or null to object
    at Object.keys (<anonymous>)
    at convertChangeData
```

This breaks the real-time functionality whenever a deletion occurs.

---

## Solution
Add a simple guard clause in `convertChangeData` to safely handle `null` or `undefined` records by returning an empty object:

```ts
if (!record) {
  return {} as Record
}
```

This ensures that subsequent operations (like `Object.keys(record)`) can execute safely without runtime errors, maintaining the stability of the Realtime subscription even when `DELETE` events are triggered.

---

## Context
- Encountered while building a Supabase-powered application where real-time updates are critical.
- The error occurs consistently when deleting groups via the following RPC function:

```sql
CREATE OR REPLACE FUNCTION public.delete_transaction_group(p_group_id uuid)
RETURNS void AS $$
DECLARE
  v_user_id uuid := auth.uid();
BEGIN
  PERFORM 1 
  FROM transaction.group 
  WHERE id = p_group_id;
  
  DELETE FROM transaction.group 
  WHERE id = p_group_id;
END;
$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = transaction;
```

- `DELETE` events emit payloads without `record` data, triggering the type error.

---

## Why this fix is important
- Prevents real-time subscription crashes during normal `DELETE` operations.
- Maintains application stability in production environments.
- Aligns Realtime event handling to safely support all event types (`INSERT`, `UPDATE`, and `DELETE`).

---

## Testing
- Subscribed to the `transaction.groups` table with a Realtime listener.
- Triggered `DELETE` operations through the `delete_transaction_group` function.
- Confirmed no runtime errors were thrown after the fix.
- Confirmed that the real-time subscription continues to function as expected after deletions.

---

✅ Safe and minimal fix.  
✅ No breaking changes introduced.  
✅ Better resilience for real-time subscriptions.

---

**Please review and merge this fix to ensure better Realtime stability.**  
Thank you! 🙌

---