### PR TITLE
fix: make the exports section compatible with Deno 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,9 @@
   },
   "exports": {
     ".": {
-      "import": "./dist/module/index.js",
-      "require": "./dist/main/index.js"
+      "node":"./dist/main/index.js",
+      "browser": "./dist/module/index.js",
+      "default": "./dist/main/index.js"
     },
     "./websocket": {
       "node": "./dist/WebSocket.js",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

In Deno 1 (edge-runtime <= 1.67.4), there seems to be an issue when importing node packages in import (es module) mode, so I guess the require (commonjs) should be the default.

Context: https://supabase.slack.com/archives/C037QCFELUR/p1748899818102949?thread_ts=1748869838.255779&cid=C037QCFELUR