### PR TITLE
fix: soft deprecation of headers and simplify ws socket connection

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,7 +1,6 @@
 import { version } from './version'
 
-export const DEFAULT_HEADERS = { 'X-Client-Info': `realtime-js/${version}` }
-
+export const DEFAULT_VERSION = `realtime-js/${version}`
 export const VSN: string = '1.0.0'
 
 export const VERSION = version


### PR DESCRIPTION
## What kind of change does this PR introduce?

starts deprecation of the headers option as now the option won't impact anything in the code

version will be sent in the payload to ensure we still are able to check which version of the client lib is used
