### PR TITLE
fix: resolve 'ws' peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "@supabase/node-fetch": "^2.6.13",
         "@types/phoenix": "^1.6.6",
         "@types/ws": "^8.18.1",
-        "isows": "^1.0.7"
+        "isows": "^1.0.7",
+        "ws": "^8.18.2"
       },
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.16.4",
@@ -7748,7 +7749,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
       "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
   "dependencies": {
     "@supabase/node-fetch": "^2.6.13",
     "@types/phoenix": "^1.6.6",
-    "isows": "^1.0.7"
+    "isows": "^1.0.7",
+    "@types/ws": "^8.18.1",
+    "ws": "^8.18.2"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.16.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,15 @@ importers:
       '@types/phoenix':
         specifier: ^1.6.6
         version: 1.6.6
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       isows:
         specifier: ^1.0.7
         version: 1.0.7(ws@8.18.2)
+      ws:
+        specifier: ^8.18.2
+        version: 8.18.2
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.16.4
@@ -554,6 +560,9 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@vitest/coverage-v8@3.1.4':
     resolution: {integrity: sha512-G4p6OtioySL+hPV7Y6JHlhpsODbJzt1ndwHAFkyk6vVjpK03PFsKnauZIzcd0PrK4zAbc5lc+jeZ+eNGiMA+iw==}
@@ -2858,7 +2867,6 @@ snapshots:
   '@types/node@22.15.21':
     dependencies:
       undici-types: 6.21.0
-    optional: true
 
   '@types/phoenix@1.6.6': {}
 
@@ -2869,6 +2877,10 @@ snapshots:
   '@types/sinonjs__fake-timers@8.1.5': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.15.21
 
   '@vitest/coverage-v8@3.1.4(vitest@3.1.4(@types/node@22.15.21)(jsdom@16.7.0))':
     dependencies:
@@ -4735,8 +4747,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@6.21.0:
-    optional: true
+  undici-types@6.21.0: {}
 
   unicode-emoji-modifier-base@1.0.0: {}
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Hot fix for missing peer dependency (`ws` is resolved as `peerDependency` for `isows`)

## What is the current behavior?

Newest package release fails during usage due to missing peer dependency (`ws`)

## What is the new behavior?

The peer dependency is installed within the `realtime-js`

## Additional context

`supabase-js` issue: https://github.com/supabase/supabase-js/issues/1462