### PR TITLE
feat: Presence enabled flag on join payload

### DIFF
--- a/src/RealtimeChannel.ts
+++ b/src/RealtimeChannel.ts
@@ -429,9 +429,7 @@ export default class RealtimeChannel {
         'channel',
         `resubscribe to ${this.topic} due to change in presence callbacks on joined channel`
       )
-      this.unsubscribe().then(() => {
-        this.subscribe()
-      })
+      this.unsubscribe().then(() => this.subscribe())
     }
     return this._on(type, filter, callback)
   }

--- a/src/RealtimeChannel.ts
+++ b/src/RealtimeChannel.ts
@@ -23,7 +23,7 @@ export type RealtimeChannelOptions = {
     /**
      * key option is used to track presence payload across clients
      */
-    presence?: { key?: string }
+    presence?: { key?: string; enabled?: boolean }
     /**
      * defines if the channel is private or not and if RLS policies will be used to check data
      */
@@ -154,7 +154,7 @@ export default class RealtimeChannel {
     this.params.config = {
       ...{
         broadcast: { ack: false, self: false },
-        presence: { key: '' },
+        presence: { key: '', enabled: false },
         private: false,
       },
       ...params.config,
@@ -225,6 +225,7 @@ export default class RealtimeChannel {
       this._onError((e: Error) =>
         callback?.(REALTIME_SUBSCRIBE_STATES.CHANNEL_ERROR, e)
       )
+
       this._onClose(() => callback?.(REALTIME_SUBSCRIBE_STATES.CLOSED))
 
       const accessTokenPayload: { access_token?: string } = {}
@@ -414,9 +415,17 @@ export default class RealtimeChannel {
   ): RealtimeChannel
   on(
     type: `${REALTIME_LISTEN_TYPES}`,
-    filter: { event: string;[key: string]: string },
+    filter: { event: string; [key: string]: string },
     callback: (payload: any) => void
   ): RealtimeChannel {
+    if (type === REALTIME_LISTEN_TYPES.PRESENCE) {
+      this.updateJoinPayload({
+        config: {
+          ...this.params.config,
+          presence: { ...this.params.config.presence, enabled: true },
+        },
+      })
+    }
     return this._on(type, filter, callback)
   }
   /**
@@ -535,10 +544,9 @@ export default class RealtimeChannel {
       if (!this._canPush()) {
         leavePush.trigger('ok', {})
       }
+    }).finally(() => {
+      leavePush?.destroy()
     })
-      .finally(() => {
-        leavePush?.destroy()
-      })
   }
   /**
    * Teardown the channel.
@@ -649,7 +657,7 @@ export default class RealtimeChannel {
                 payload.ids?.includes(bindId) &&
                 (bindEvent === '*' ||
                   bindEvent?.toLocaleLowerCase() ===
-                  payload.data?.type.toLocaleLowerCase())
+                    payload.data?.type.toLocaleLowerCase())
               )
             } else {
               const bindEvent = bind?.filter?.event?.toLocaleLowerCase()
@@ -714,7 +722,6 @@ export default class RealtimeChannel {
   /** @internal */
   _on(type: string, filter: { [key: string]: any }, callback: Function) {
     const typeLower = type.toLocaleLowerCase()
-
     const binding = {
       type: typeLower,
       filter: filter,

--- a/src/RealtimePresence.ts
+++ b/src/RealtimePresence.ts
@@ -64,6 +64,7 @@ export default class RealtimePresence {
   state: RealtimePresenceState = {}
   pendingDiffs: RawPresenceDiff[] = []
   joinRef: string | null = null
+  enabled: boolean = false
   caller: {
     onJoin: PresenceOnJoinCallback
     onLeave: PresenceOnLeaveCallback

--- a/test/RealtimeChannel.test.ts
+++ b/test/RealtimeChannel.test.ts
@@ -52,7 +52,7 @@ describe('constructor', () => {
     assert.deepEqual(channel.params, {
       config: {
         broadcast: { ack: false, self: false },
-        presence: { key: '' },
+        presence: { key: '', enabled: false },
         private: false,
       },
     })
@@ -76,13 +76,14 @@ describe('constructor', () => {
     assert.deepEqual(joinPush.payload, {
       config: {
         broadcast: { ack: false, self: false },
-        presence: { key: '' },
+        presence: { key: '', enabled: false },
         private: false,
       },
     })
     assert.equal(joinPush.event, 'phx_join')
     assert.equal(joinPush.timeout, 1234)
   })
+
   test('sets up joinPush object with private defined', () => {
     const socket = new RealtimeClient(url, {
       transport: WebSocket,
@@ -99,7 +100,62 @@ describe('constructor', () => {
     assert.deepEqual(joinPush.payload, {
       config: {
         broadcast: { ack: false, self: false },
-        presence: { key: '' },
+        presence: { key: '', enabled: false },
+        private: true,
+      },
+    })
+    assert.equal(joinPush.event, 'phx_join')
+    assert.equal(joinPush.timeout, 1234)
+  })
+
+  test('sets up joinPush object with presence disabled if no on with type presence is defined', () => {
+    const socket = new RealtimeClient(url, {
+      transport: WebSocket,
+      timeout: 1234,
+    })
+
+    channel = new RealtimeChannel(
+      'topic',
+      { config: { private: true } },
+      socket
+    )
+
+    const joinPush = channel.joinPush
+
+    assert.deepEqual(joinPush.channel, channel)
+    assert.deepEqual(joinPush.payload, {
+      config: {
+        broadcast: { ack: false, self: false },
+        presence: { key: '', enabled: false },
+        private: true,
+      },
+    })
+
+    assert.equal(joinPush.event, 'phx_join')
+    assert.equal(joinPush.timeout, 1234)
+  })
+
+  test('sets up joinPush object with presence enabled if on with type presence is defined', () => {
+    const socket = new RealtimeClient(url, {
+      transport: WebSocket,
+      timeout: 1234,
+    })
+
+    channel = new RealtimeChannel(
+      'topic',
+      { config: { private: true } },
+      socket
+    )
+
+    channel.on('presence', { event: 'join' }, ({}) => {})
+
+    const joinPush = channel.joinPush
+
+    assert.deepEqual(joinPush.channel, channel)
+    assert.deepEqual(joinPush.payload, {
+      config: {
+        broadcast: { ack: false, self: false },
+        presence: { key: '', enabled: true },
         private: true,
       },
     })
@@ -157,13 +213,8 @@ describe('subscribe', () => {
     assert.deepEqual(channel.joinPush.payload, {
       access_token: 'token123',
       config: {
-        broadcast: {
-          ack: false,
-          self: false,
-        },
-        presence: {
-          key: '',
-        },
+        broadcast: { ack: false, self: false },
+        presence: { key: '', enabled: false },
         postgres_changes: [],
         private: false,
       },
@@ -189,7 +240,7 @@ describe('subscribe', () => {
         payload: {
           config: {
             broadcast: { ack: false, self: false },
-            presence: { key: '' },
+            presence: { key: '', enabled: false },
             postgres_changes: [],
             private: false,
           },
@@ -206,7 +257,7 @@ describe('subscribe', () => {
     sinon.stub(socket, '_makeRef').callsFake(() => defaultRef)
     const spy = sinon.spy(socket, 'push')
     const cbSpy = sinon.spy()
-    const func = () => { }
+    const func = () => {}
 
     channel.bindings.postgres_changes = [
       {
@@ -258,7 +309,7 @@ describe('subscribe', () => {
         payload: {
           config: {
             broadcast: { ack: false, self: false },
-            presence: { key: '' },
+            presence: { key: '', enabled: false },
             postgres_changes: [
               { event: '*', schema: '*' },
               { event: 'INSERT', schema: 'public', table: 'test' },
@@ -308,7 +359,7 @@ describe('subscribe', () => {
   test('unsubscribes to channel with incorrect server postgres_changes resp', () => {
     const unsubscribeSpy = sinon.spy(channel, 'unsubscribe')
     const callbackSpy = sinon.spy()
-    const dummyCallback = () => { }
+    const dummyCallback = () => {}
 
     channel.bindings.postgres_changes = [
       {
@@ -359,7 +410,7 @@ describe('subscribe', () => {
 
     assert.equal(joinPush.timeout, defaultTimeout)
 
-    channel.subscribe(() => { }, newTimeout)
+    channel.subscribe(() => {}, newTimeout)
 
     assert.equal(joinPush.timeout, newTimeout)
   })
@@ -502,7 +553,7 @@ describe('joinPush', () => {
     })
 
     test("sends and empties channel's buffered pushEvents", () => {
-      const pushEvent: any = { send() { } }
+      const pushEvent: any = { send() {} }
       const spy = sinon.spy(pushEvent, 'send')
       channel.pushBuffer.push(pushEvent)
       helpers.receiveOk()
@@ -656,7 +707,7 @@ describe('joinPush', () => {
 
     test("does not trigger channel's buffered pushEvents", () => {
       // @ts-ignore - we're only testing the pushBuffer
-      const pushEvent: Push = { send: () => { } }
+      const pushEvent: Push = { send: () => {} }
       const spy = sinon.spy(pushEvent, 'send')
 
       channel.pushBuffer.push(pushEvent)
@@ -902,15 +953,14 @@ describe('on', () => {
     channel.unsubscribe()
   })
 
-  test('sets up callback for event', () => {
+  test('sets up callback for broadcast', () => {
     const spy = sinon.spy()
 
-    channel._trigger('event', {}, defaultRef)
+    channel._trigger('broadcast', '*', defaultRef)
     assert.ok(!spy.called)
-    //@ts-ignore - we're aware that we're a non supported event, needs improvements to our testing methodology
-    channel.on('event', {}, spy)
+    channel.on('broadcast', { event: '*' }, spy)
 
-    channel._trigger('event', {}, defaultRef)
+    channel._trigger('broadcast', { event: '*' }, defaultRef)
 
     assert.ok(spy.called)
   })
@@ -919,16 +969,13 @@ describe('on', () => {
     const spy = sinon.spy()
     const ignoredSpy = sinon.spy()
 
-    channel._trigger('event', {}, defaultRef)
+    channel._trigger('broadcast', { event: 'test' }, defaultRef)
 
     assert.ok(!ignoredSpy.called)
-    //@ts-ignore - we're aware that we're a non supported event, needs improvements to our testing methodology
-    channel.on('event', {}, spy)
+    channel.on('broadcast', { event: 'test' }, spy)
+    channel.on('broadcast', { event: 'ignore' }, ignoredSpy)
 
-    //@ts-ignore - we're aware that we're a non supported event, needs improvements to our testing methodology
-    channel.on('otherEvent', {}, ignoredSpy)
-
-    channel._trigger('event', {}, defaultRef)
+    channel._trigger('broadcast', { event: 'test' }, defaultRef)
 
     assert.ok(!ignoredSpy.called)
   })
@@ -939,9 +986,8 @@ describe('on', () => {
     channel._trigger('realtime', { event: 'INSERT' }, defaultRef)
     assert.ok(!spy.called)
 
-    //@ts-ignore - we're aware that we're a non supported event, needs improvements to our testing methodology
-    channel.on('realtime', { event: 'INSERT' }, spy)
-    channel._trigger('realtime', { event: 'INSERT' }, defaultRef)
+    channel.on('broadcast', { event: 'INSERT' }, spy)
+    channel._trigger('broadcast', { event: 'INSERT' }, defaultRef)
     assert.ok(spy.called)
   })
 })
@@ -961,22 +1007,18 @@ describe('off', () => {
     const spy2 = sinon.spy()
     const spy3 = sinon.spy()
 
-    //@ts-ignore - we're aware that we're a non supported event, needs improvements to our testing methodology
-    channel.on('event', {}, spy1)
+    channel.on('broadcast', { event: 'test1' }, spy1)
+    channel.on('broadcast', { event: 'test2' }, spy2)
+    channel.on('broadcast', { event: 'test3' }, spy3)
 
-    //@ts-ignore - we're aware that we're a non supported event, needs improvements to our testing methodology
-    channel.on('event', {}, spy2)
+    channel._off('broadcast', { event: 'test1' })
 
-    //@ts-ignore - we're aware that we're a non supported event, needs improvements to our testing methodology
-    channel.on('other', {}, spy3)
-
-    channel._off('event', {})
-
-    channel._trigger('event', {}, defaultRef)
-    channel._trigger('other', {}, defaultRef)
+    channel._trigger('broadcast', { event: 'test1' }, defaultRef)
+    channel._trigger('broadcast', { event: 'test2' }, defaultRef)
+    channel._trigger('broadcast', { event: 'test3' }, defaultRef)
 
     assert.ok(!spy1.called)
-    assert.ok(!spy2.called)
+    assert.ok(spy2.called)
     assert.ok(spy3.called)
   })
 })
@@ -1422,7 +1464,7 @@ describe('unsubscribe', () => {
 
   test('cleans up leavePush on successful unsubscribe', async () => {
     await channel.unsubscribe()
-    
+
     assert.ok(destroySpy.calledTwice) // Once for joinPush, once for leavePush
     assert.equal(channel.state, CHANNEL_STATES.closed)
   })
@@ -1432,9 +1474,9 @@ describe('unsubscribe', () => {
       // Simulate timeout by not responding
       clock.tick(defaultTimeout + 1)
     })
-    
+
     const result = await channel.unsubscribe()
-    
+
     assert.ok(destroySpy.calledTwice) // Once for joinPush, once for leavePush
     assert.equal(result, 'timed out')
     assert.equal(channel.state, CHANNEL_STATES.closed)
@@ -1447,9 +1489,9 @@ describe('unsubscribe', () => {
   //     const leavePush = channel['joinPush']
   //     leavePush.trigger('error', {})
   //   })
-    
+
   //   const result = await channel.unsubscribe()
-    
+
   //   assert.ok(destroySpy.calledTwice) // Once for joinPush, once for leavePush
   //   assert.equal(result, 'error')
   //   assert.equal(channel.state, CHANNEL_STATES.closed)
@@ -1457,9 +1499,9 @@ describe('unsubscribe', () => {
 
   test('cleans up leavePush even if socket is not connected', async () => {
     sinon.stub(socket, 'isConnected').returns(false)
-    
+
     await channel.unsubscribe()
-    
+
     assert.ok(destroySpy.calledTwice) // Once for joinPush, once for leavePush
     assert.equal(channel.state, CHANNEL_STATES.closed)
   })

--- a/test/RealtimeChannel.test.ts
+++ b/test/RealtimeChannel.test.ts
@@ -949,11 +949,13 @@ describe('on', () => {
     socket = new RealtimeClient('ws://example.com/socket')
     sinon.stub(socket, '_makeRef').callsFake(() => defaultRef)
     channel = socket.channel('topic')
+    clock.restore()
   })
 
   afterEach(() => {
     socket.disconnect()
     channel.unsubscribe()
+    clock = sinon.useFakeTimers()
   })
 
   test('sets up callback for broadcast', () => {
@@ -994,8 +996,7 @@ describe('on', () => {
     assert.ok(spy.called)
   })
 
-  // Need some help with this test...
-  test.skip('when we bind a new callback on an already joined channel we resubscribe with new join payload', async () => {
+  test('when we bind a new callback on an already joined channel we resubscribe with new join payload', async () => {
     channel.on('broadcast', { event: 'test' }, sinon.spy())
     channel.subscribe()
     channel.joinPush.trigger('ok', {})
@@ -1013,9 +1014,11 @@ describe('on', () => {
         private: false,
       },
     })
-    await new Promise((resolve) => setTimeout(resolve, 100))
+
     channel.on('presence', { event: 'join' }, sinon.spy())
-    await new Promise((resolve) => setTimeout(resolve, 100))
+
+    await new Promise((resolve) => setTimeout(resolve, 3000))
+
     assert.deepEqual(channel.joinPush.payload, {
       config: {
         broadcast: {
@@ -1024,7 +1027,7 @@ describe('on', () => {
         },
         postgres_changes: [],
         presence: {
-          enabled: false,
+          enabled: true,
           key: '',
         },
         private: false,

--- a/test/RealtimeClient.test.ts
+++ b/test/RealtimeClient.test.ts
@@ -217,7 +217,7 @@ describe('channel', () => {
     assert.deepEqual(channel.params, {
       config: {
         broadcast: { ack: false, self: false },
-        presence: { key: '' },
+        presence: { key: '', enabled: false },
         private: false,
       },
       one: 'two',
@@ -232,7 +232,7 @@ describe('channel', () => {
     assert.deepEqual(channel.params, {
       config: {
         broadcast: { ack: false, self: false },
-        presence: { key: '' },
+        presence: { key: '', enabled: false },
         private: true,
       },
       one: 'two',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Changes the join payload to include a flag to enable/disable presence features. The flag is automatically set if we find a callback for any event of type `presence`.

Cleaned up tests to also be more inline with the expected types.
