### PR TITLE
fix: Set auth on connect and reconnect flows

### DIFF
--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -186,6 +186,7 @@ export default class RealtimeClient {
       ? options.decode
       : this.serializer.decode.bind(this.serializer)
     this.reconnectTimer = new Timer(async () => {
+      await this.setAuth()
       this.disconnect()
       this.connect()
     }, this.reconnectAfterMs)
@@ -216,6 +217,8 @@ export default class RealtimeClient {
     }
     this.conn = new this.transport(this.endpointURL()) as WebSocketLike
     this.setupConnection()
+    // Set the token on connect
+    setTimeout(() => this.setAuth(), 0)
   }
 
   /**

--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -217,7 +217,11 @@ export default class RealtimeClient {
     this.conn = new this.transport(this.endpointURL()) as WebSocketLike
     this.setupConnection()
     // Set the token on connect
-    setTimeout(() => this.setAuth(), 0)
+    setTimeout(() => {
+      this.setAuth().catch((e) => {
+        this.log('error', 'error setting auth', e)
+      })
+    }, 0)
   }
 
   /**

--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -186,7 +186,6 @@ export default class RealtimeClient {
       ? options.decode
       : this.serializer.decode.bind(this.serializer)
     this.reconnectTimer = new Timer(async () => {
-      await this.setAuth()
       this.disconnect()
       this.connect()
     }, this.reconnectAfterMs)

--- a/test/RealtimeChannel.test.ts
+++ b/test/RealtimeChannel.test.ts
@@ -1017,7 +1017,7 @@ describe('on', () => {
 
     channel.on('presence', { event: 'join' }, sinon.spy())
 
-    await new Promise((resolve) => setTimeout(resolve, 3000))
+    await new Promise((resolve) => setTimeout(resolve, 100))
 
     assert.deepEqual(channel.joinPush.payload, {
       config: {

--- a/test/RealtimeClient.test.ts
+++ b/test/RealtimeClient.test.ts
@@ -770,7 +770,9 @@ describe('socket close event', () => {
     assert.strictEqual(accessToken.callCount, 1)
     expect(socket.accessTokenValue).toBe(tokens[0])
 
+    // Call the callback and wait for async operations to complete
     await socket.reconnectTimer.callback()
+    await new Promise((resolve) => setTimeout(resolve, 100))
     expect(socket.accessTokenValue).toBe(tokens[1])
     assert.strictEqual(accessToken.callCount, 2)
   })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Set auth on connect and reconnect flows.

I've also changed the tests to focus on using WS events instead of calling private methods 