### PR TITLE
Send a Heartbeat for initial connection error

### DIFF
--- a/src/RealtimeClient.ts
+++ b/src/RealtimeClient.ts
@@ -607,6 +607,7 @@ export default class RealtimeClient {
   private _onConnError(error: Event) {
     this.log('transport', `${error}`)
     this._triggerChanError()
+    this.heartbeatCallback('error')
     this.stateChangeCallbacks.error.forEach((callback) => callback(error))
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Add missing heartbeat on connection error.

## What is the current behavior?

If the Supabase instance is unreachable during initial realtime connection, there is no status update available.

## What is the new behavior?

Trigger a heartbeat-callback with 'error' on connection-error.
