### PR TITLE
fix: Websocket like type definition compatible with ws

### DIFF
--- a/src/lib/websocket-factory.ts
+++ b/src/lib/websocket-factory.ts
@@ -10,15 +10,22 @@ export interface WebSocketLike {
   close(code?: number, reason?: string): void
   send(data: string | ArrayBufferLike | Blob | ArrayBufferView): void
 
-  onopen: ((this: any, ev: Event) => any) | null
-  onmessage: ((this: any, ev: MessageEvent) => any) | null
-  onclose: ((this: any, ev: CloseEvent) => any) | null
-  onerror: ((this: any, ev: Event) => any) | null
+  // Browser WebSocket style events (optional for ws package compatibility)
+  onopen?: ((this: any, ev: Event) => any) | null
+  onmessage?: ((this: any, ev: MessageEvent) => any) | null
+  onclose?: ((this: any, ev: CloseEvent) => any) | null
+  onerror?: ((this: any, ev: Event) => any) | null
 
-  addEventListener(type: string, listener: EventListener): void
-  removeEventListener(type: string, listener: EventListener): void
+  // EventEmitter style events (for ws package compatibility)
+  on?: (event: string, listener: (...args: any[]) => void) => any
+  off?: (event: string, listener: (...args: any[]) => void) => any
+  once?: (event: string, listener: (...args: any[]) => void) => any
 
-  // Add additional properties that may exist on WebSocket implementations
+  // DOM-style event methods (optional for ws package)
+  addEventListener?: (type: string, listener: EventListener) => void
+  removeEventListener?: (type: string, listener: EventListener) => void
+
+  // Additional properties that may exist on WebSocket implementations
   binaryType?: string
   bufferedAmount?: number
   extensions?: string


### PR DESCRIPTION
## What kind of change does this PR introduce?

Update WebSocketLike type definition to be compatible with `ws` usage.
