### PR TITLE
chore: trigger action from forks

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -20,6 +20,12 @@ on:
   push:
     branches:
       - master
+    paths:
+      - 'src/**'
+      - 'test/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
   
   # PR triggers - only when labeled
   # Using pull_request_target to access secrets when PRs come from forks


### PR DESCRIPTION
## What kind of change does this PR introduce?

Using `pull_request_target` to access secrets when PRs come from forks. This is secure, since we control which PRs trigger the preview.

## What is the current behavior?

The workflow cannot run on PRs from forks because it does not have access to `app-id`.

## What is the new behavior?

Use `pull_request_target` to get access to secrets.
