### PR TITLE
chore: fix preview release to use correct target

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -22,7 +22,6 @@ on:
       - master
     paths:
       - 'src/**'
-      - 'test/**'
       - 'package.json'
       - 'package-lock.json'
       - 'tsconfig.json'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Remove `test` dir from the trigger paths.

## What is the current behavior?

If a change is made in the `test` dir, it will trigger the tests in `supabase-js`. No need for that.

## What is the new behavior?

Changes in `test` do not trigger anything.
