### PR TITLE
fix(realtime): handle null at convertChangeData

### DIFF
--- a/src/lib/transformers.ts
+++ b/src/lib/transformers.ts
@@ -60,10 +60,14 @@ type Record = {
  */
 export const convertChangeData = (
   columns: Columns,
-  record: Record,
+  record: Record | null,
   options: { skipTypes?: string[] } = {}
 ): Record => {
   const skipTypes = options.skipTypes ?? []
+
+  if (!record) {
+    return {}
+  }
 
   return Object.keys(record).reduce((acc, rec_key) => {
     acc[rec_key] = convertColumn(rec_key, columns, record, skipTypes)

--- a/test/transformers.test.ts
+++ b/test/transformers.test.ts
@@ -46,6 +46,18 @@ test('convertChangeData', () => {
     ),
     { first_name: 'Paul', age: null }
   )
+
+  assert.deepEqual(
+    convertChangeData(
+      [
+        { name: 'first_name', type: 'text' },
+        { name: 'age', type: 'int4' },
+      ],
+      null,
+      {}
+    ),
+    {}
+  )
 })
 
 test('convertColumn', () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When a record is changed, and that record is used by a row-level access policy, the record arriving in the subscription can be null. When convertChangeData tries to Object.keys(record), we get error:
```
@supabase_supabase-js.js?v=02935ef6:1614 Uncaught TypeError: Cannot convert undefined or null to object
    at Object.keys (<anonymous>)
    at convertChangeData (@supabase_supabase-js.js?v=02935ef6:1614:17)
    at _RealtimeChannel._getPayloadRecords (@supabase_supabase-js.js?v=02935ef6:2552:21)
    at @supabase_supabase-js.js?v=02935ef6:2438:83
    at Array.map (<anonymous>)
    at _RealtimeChannel._trigger (@supabase_supabase-js.js?v=02935ef6:2425:10)
    at @supabase_supabase-js.js?v=02935ef6:2947:96
    at Array.forEach (<anonymous>)
    at @supabase_supabase-js.js?v=02935ef6:2947:67
    at Serializer.decode (@supabase_supabase-js.js?v=02935ef6:1536:14)
```
<img width="729" height="259" alt="image" src="https://github.com/user-attachments/assets/b1080ecf-fd7b-462c-a73f-ac6a23000aaf" />


## What is the new behavior?

If the record is null, return an empty object to the caller of convertChangeData.

## Additional context

Updated also the signature of the call to reflect that `record` can also be `null`.